### PR TITLE
Expanded tags definitions

### DIFF
--- a/src/config/sidebar.yml
+++ b/src/config/sidebar.yml
@@ -30,8 +30,10 @@
       link: '/standards/uk'
     - label: 'US Devices'
       link: '/standards/us'
-- label: Shared guides
+- label: Guides
   items:
+    - label: 'Adding Devices'
+      link: '/adding-devices/'
     - label: 'Prepare a device with tuya-convert'
       link: '/guides/tuya-convert/'
 # - label: External Links

--- a/src/docs/adding-devices.md
+++ b/src/docs/adding-devices.md
@@ -27,12 +27,16 @@ standard: uk, us
 ---
 ```
 
-| Field            | Description                 | Allowable Options                                                                 | Required? |
-| ---------------- | --------------------------- | --------------------------------------------------------------------------------- | --------- |
-| `title`          | Device Title                |                                                                                   | Yes       |
-| `date-published` | Date Published              | Formatting: `YYYY-MM-DD HH:MM:SS +/-TTTT` (Time and Timezone offset are optional) | Yes       |
-| `type`           | Type of Device              | `plug`, `light`, `switch`, `dimmer` , `relay`, `sensor`, `misc`                   | Yes       |
-| `standard`       | Electrical standard country | `uk`, `us`, `eu`, `au`, `in`, `global`                                            | Yes       |
+| Field              | Description                                           | Allowable Options                                                                                                                                | Required? |
+|--------------------|-------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
+| `title`            | Device Title                                          |                                                                                                                                                  | Yes       |
+| `date-published`   | Date Published                                        | Formatting: `YYYY-MM-DD HH:MM:SS +/-TTTT` (Time and Timezone offset are optional)                                                                | Yes       |
+| `type`             | Type of Device                                        | `plug`, `light`, `switch`, `dimmer` , `relay`, `sensor`, `misc`                                                                                  | Yes       |
+| `standard`         | Electrical standard country                           | `uk`, `us`, `eu`, `au`, `in`, `global`                                                                                                           | Yes       |
+| `board`            | Type of board used in product                         | `esp8266`, `esp32`                                                                                                                               | No        |
+| `project-url`      | URL for product or GitHub Repo                        |                                                                                                                                                  | No        |
+| `made-for-esphome` | Has the manufacturer certified the device for ESPHome | `True`, `False`                                                                                                                                  | No        |
+| `difficulty`       | Difficulty rating                                     | `1`: Comes with ESPhome <br /> `2`: Plug-n-flash<br /> `3`: Disassembly required<br /> `4`: Soldering required<br /> `5`: Chip needs replacement | No        |
 
 ## Images
 


### PR DESCRIPTION
TLDR; This pull request proposes a specification for expanding the tags options for the devices listed in this database

----

I submitted a [reddit post](https://www.reddit.com/r/Esphome/comments/12n0884/list_of_esphome_products/) looking for a sort of database of devices that were compatible with ESPHome. I've had a go at a modified spec for adding some extended attributes to the devices pages. In essence, it entails:

- board: the board type used in the project. At the moment I've just added esp8266 and esp32. Not sure if it needs to be more granular than that, open to feedback...
- project-url: so there's a nice holder to a link for the product or GitHub repo that contains the details about the project
- made-for-esphome: bool to capture if the manufacturer has conformed to the [made for esphome](https://esphome.io/guides/made_for_esphome.html) spec
- difficulty: to provide a rating for whether this is a 'off the shelf' compatibility. Its based on another commenters categorisation, it seemed a good starting point but happy for feedback.

I spent the day hacking around with gatsby and worked out how to extend the site. Before I put in the legwork to get it working properly, I was hoping you would adopt this as a starting point? From there, I'm happy to build out the devices page template and a couple of list pages to show the data properly.