### PR TITLE
Update index.md to working icon format

### DIFF
--- a/src/docs/devices/Sonoff-Mini-Relay/index.md
+++ b/src/docs/devices/Sonoff-Mini-Relay/index.md
@@ -101,7 +101,7 @@ binary_sensor:
 switch:
   - platform: gpio
     name: ${device_name}_switch
-    icon: "mdi: lightbulb_outline"
+    icon: "mdi:lightbulb_outline"
     pin: GPIO12
     id: relay_1
     restore_mode: restore_default_off


### PR DESCRIPTION
icon was throwing an error due to a spelling mistake