### PR TITLE
Update index.md

### DIFF
--- a/src/docs/devices/eWeLink-SANT-SUD01/index.md
+++ b/src/docs/devices/eWeLink-SANT-SUD01/index.md
@@ -109,6 +109,14 @@ switch:
         return false;
       }
 
+#Replace the lambda function above with the one below if you have inverted the relay output
+#    lambda: |-
+#      if (id(power_status_pulses).state > 60.0f) {
+#        return false;
+#      } else {
+#        return true;
+#      }
+
     # Mimic the user pressing the button
     turn_on_action:
       - script.execute: regular_press
@@ -118,5 +126,7 @@ switch:
 output:
   - platform: gpio
     id: out_relay
+    #Inverts relay operation, this avoids force shutdown behavior on some motherboards. Uncomment here and replace the above lambda if you are having this problem.
+    #inverted: True
     pin: GPIO12
 ```


### PR DESCRIPTION
This change mitigates the forced shutdown behavior issue. In some devices apparently the output relay is inverted (always on and not off), making the computer recognize as always pressing the power button, forcing the shutdown of the system right after being turned on. I commented the code that corrects it because it gives the possibility to be corrected easily if someone has this problem.