### PR TITLE
remove platform: in esphome section in Sonoff S26 example

### DIFF
--- a/src/docs/devices/Sonoff-S26/index.md
+++ b/src/docs/devices/Sonoff-S26/index.md
@@ -20,7 +20,6 @@ board: esp8266
 # Basic Config
 esphome:
   name: sonoffs26_1
-  platform: ESP8266
   
 esp8266:
   board: esp01_1m


### PR DESCRIPTION
Causes compile time error as-is; compiles normally like this.