### PR TITLE
Update Device: Treatlife DS02s to add Advanced Configuration Options

### DIFF
--- a/src/docs/devices/TreatLife-DS02S/index.md
+++ b/src/docs/devices/TreatLife-DS02S/index.md
@@ -94,7 +94,6 @@ select:
     id: "dimmer_mode"
     name: "Dimming Mode"
     enum_datapoint: 4
-    optimistic: true
     options:
       0: Mode 1 # Index 0
       1: Mode 2 # Index 1

--- a/src/docs/devices/TreatLife-DS02S/index.md
+++ b/src/docs/devices/TreatLife-DS02S/index.md
@@ -86,7 +86,7 @@ light:
 
 Below are some advanced configuration options that may be required if your dimmer is not behaving as expected.
 
-This will add a select component to allow changing the Dimming Mode on the MCU. This will give you a drop-down of Dimming Mode Options. Recommended to try out all and see which works best, then set it statically.
+This will add a select component to allow changing the dimming mode on the MCU, giving you a drop-down of dimming mode options. Recommended to try out all and see which works best, then set it statically.
 
 ```yaml
 select:

--- a/src/docs/devices/TreatLife-DS02S/index.md
+++ b/src/docs/devices/TreatLife-DS02S/index.md
@@ -86,16 +86,29 @@ light:
 
 Below are some advanced configuration options that may be required if your dimmer is not behaving as expected.
 
+This will add a select component to allow changing the Dimming Mode on the MCU. This will give you a drop-down of Dimming Mode Options. Recommended to try out all and see which works best, then set it statically.
+
 ```yaml
-# Select Component to allow changing the Dimming mode on the MCU. This will give you a drop-down of Dimming Mode Options.
-# Recommended to try out all and see which works best, then set it statically.
 select:
   - platform: "tuya"
+    id: "dimmer_mode"
     name: "Dimming Mode"
     enum_datapoint: 4
     optimistic: true
     options:
-      0: Mode 1
-      1: Mode 2
-      2: Mode 3
+      0: Mode 1 # Index 0
+      1: Mode 2 # Index 1
+      2: Mode 3 # Index 2
+```
+
+Here is a script that will set the dimming mode in a more static fashion when ESPHome Reboots. This will select based on the index of the select component instead of by name of the mode. This can still be set via drop down if this script is included, it will just set it to this value every boot.
+
+```yaml
+esphome:
+  on_boot:
+    then:
+      - delay: 30s # Wait 30 seconds because even with a priority of -200.0, it will not update the datapoint.
+      - select.set_index:
+          id: "dimmer_mode"
+          index: 2
 ```

--- a/src/docs/devices/TreatLife-DS02S/index.md
+++ b/src/docs/devices/TreatLife-DS02S/index.md
@@ -87,7 +87,7 @@ light:
 Below are some advanced configuration options that may be required if your dimmer is not behaving as expected.
 
 ```yaml
-# Select Component to allow changing the Dimming mode on the MCU. This will give you a drop-down of Dimming Mode Options. 
+# Select Component to allow changing the Dimming mode on the MCU. This will give you a drop-down of Dimming Mode Options.
 # Recommended to try out all and see which works best, then set it statically.
 select:
   - platform: "tuya"

--- a/src/docs/devices/TreatLife-DS02S/index.md
+++ b/src/docs/devices/TreatLife-DS02S/index.md
@@ -85,7 +85,8 @@ light:
 ## Advanced Configuration
 Below are some advanced configuration options that may be required if your dimmer is not behaving as expected.
 ```yaml
-# Select Component to allow changing the Dimming mode on the MCU. This will give you a drop-down of Dimming Mode Options. Recommended to try out all and see which works best, then set it statically.
+# Select Component to allow changing the Dimming mode on the MCU. This will give you a drop-down of Dimming Mode Options. 
+# Recommended to try out all and see which works best, then set it statically.
 select:
   - platform: "tuya"
     name: "Dimming Mode"

--- a/src/docs/devices/TreatLife-DS02S/index.md
+++ b/src/docs/devices/TreatLife-DS02S/index.md
@@ -81,3 +81,18 @@ light:
     min_value: 100
     max_value: 1000
 ```
+
+## Advanced Configuration
+Below are some advanced configuration options that may be required if your dimmer is not behaving as expected.
+```yaml
+# Select Component to allow changing the Dimming mode on the MCU. This will give you a drop-down of Dimming Mode Options. Recommended to try out all and see which works best, then set it statically.
+select:
+  - platform: "tuya"
+    name: "Dimming Mode"
+    enum_datapoint: 4
+    optimistic: true
+    options:
+      0: Mode 1
+      1: Mode 2
+      2: Mode 3
+```

--- a/src/docs/devices/TreatLife-DS02S/index.md
+++ b/src/docs/devices/TreatLife-DS02S/index.md
@@ -83,7 +83,9 @@ light:
 ```
 
 ## Advanced Configuration
+
 Below are some advanced configuration options that may be required if your dimmer is not behaving as expected.
+
 ```yaml
 # Select Component to allow changing the Dimming mode on the MCU. This will give you a drop-down of Dimming Mode Options. 
 # Recommended to try out all and see which works best, then set it statically.


### PR DESCRIPTION
Add Advanced configuration for Treatlife DS02s devices. These devices have 3 dimming modes. This pull request adds documentation to the template to create a Tuya Select component.

Coming in the future when I figure out how to set a datapoint statically (or at least set it on boot), I will update this Advanced Configuration section with the required information as well.