### PR TITLE
Fix: total_daily_energy value

### DIFF
--- a/src/docs/devices/Sonoff-POW-Elite-20a/index.md
+++ b/src/docs/devices/Sonoff-POW-Elite-20a/index.md
@@ -98,6 +98,9 @@ sensor:
   - platform: total_daily_energy
     name: $friendly_name Total Daily Energy
     power_id: w_sensor
+    filters:
+      - multiply: 0.001
+    unit_of_measurement: kWh
 
   - platform: wifi_signal
     name: $friendly_name Wifi RSSI


### PR DESCRIPTION
total_daily_energy sensor is fed by w_sensor (measured in W), but total_daily_energy is displayed in kWh.