### PR TITLE
Fix: button instability

### DIFF
--- a/src/docs/devices/Sonoff-POW-Elite-20a/index.md
+++ b/src/docs/devices/Sonoff-POW-Elite-20a/index.md
@@ -31,6 +31,16 @@ substitutions:
 
 esphome:
   name: $device_name
+  on_boot: # Set the initial state of the template switch to the actual relay state. This will NOT change the state.
+    priority: 250.0 # Wait until WiFi is connected to allow the sensor some time to settle
+    then:
+      - if:
+          condition:
+            lambda: 'return id(v_sensor).state > 10;'
+          then:
+            - switch.turn_on: relay_1
+          else:
+            - switch.turn_off: relay_1
 
 esp32:
   board: nodemcu-32s
@@ -175,6 +185,19 @@ binary_sensor:
     id: page
     publish_initial_state: true
     internal: true
+  - platform: template
+    name: $friendly_name Load
+    id: load_on
+    lambda: |-
+      if (isnan(id(w_sensor).state)) {
+        return {};
+      } else if (id(w_sensor).state > 4) {
+        // Running
+        return true;
+      } else {
+        // Not running
+        return false;
+      }
 
 display:
   platform: tm1621
@@ -208,16 +231,6 @@ switch:
     name: $friendly_name
     optimistic: true
     id: relay_1
-    lambda: |-
-      if (isnan(id(w_sensor).state)) {
-        return {};
-      } else if (id(w_sensor).state > 4) {
-        // Running
-        return true;
-      } else {
-        // Not running
-        return false;
-      }
     turn_off_action:
       - switch.turn_on: relay_off
     turn_on_action:


### PR DESCRIPTION
- lambda detached from template switch config in order to fix the unreliable button behavior
- lambda moved to a Load detection sensor
- set the template switch state to the actual relay state on boot