### PR TITLE
Update the name for the Sonoff POWR1

### DIFF
--- a/src/docs/devices/Sonoff-POW-R1/index.md
+++ b/src/docs/devices/Sonoff-POW-R1/index.md
@@ -1,5 +1,5 @@
 ---
-title: sonoff pow r1
+title: Sonoff POWR1
 date-published: 2019-11-11
 type: plug
 standard: global
@@ -8,7 +8,7 @@ board: esp8266
 
 ## Product Images
 
-![alt text](/inside.jpg "inside")
+![A picture of the PCB inside of the SONOFF POWR1](/inside.jpg "inside")
 
 ## GPIO Pinout
 


### PR DESCRIPTION
The name for the device wasn't properly cased and thus gets sorted incorrectly any device list page that it's contained on.

Also, included an update to the alt-text for the image.