### PR TITLE
Add us/uk support to Shelly Plus 2PM

### DIFF
--- a/src/docs/devices/Shelly-Plus-2PM/index.md
+++ b/src/docs/devices/Shelly-Plus-2PM/index.md
@@ -2,7 +2,7 @@
 title: Shelly Plus 2PM
 date-published: 2022-05-07
 type: switch
-standard: eu
+standard: uk, us, eu
 board: esp32
 ---
 


### PR DESCRIPTION
The shelly plus 2pm shows it is only compatible with EU standard. However it has the same formfactor as the Shelly 1 and Shelly 1PM  


<img width="344" alt="Screenshot 2023-07-27 at 5 00 37 PM" src="https://github.com/esphome/esphome-devices/assets/242382/7c7ef8bf-5abc-4a8f-acb6-c54763c822a9">


https://www.shelly.cloud/en/products/shop/shelly-plus-2-pm

![image](https://github.com/esphome/esphome-devices/assets/242382/9b2cdced-027f-4a6c-9b52-788fe1d23f35)
