### PR TITLE
Remove logger baud rate on Sonoff Pow Elite 

### DIFF
--- a/src/docs/devices/Sonoff-POW-Elite-20a/index.md
+++ b/src/docs/devices/Sonoff-POW-Elite-20a/index.md
@@ -56,7 +56,6 @@ captive_portal:
 
 logger:
   level: INFO
-  baud_rate: 0
 
 api:
   encryption:


### PR DESCRIPTION
Removed baud rate on logger as several users report non-functioning cse7766 when set https://community.home-assistant.io/t/sonoff-pow-elite-configuration/472671/27?u=bigwoof