### PR TITLE
Remove `restore_state` from Shelly Plus Plug S config

### DIFF
--- a/src/docs/devices/Shelly-Plus-Plug-S/index.md
+++ b/src/docs/devices/Shelly-Plus-Plug-S/index.md
@@ -271,7 +271,6 @@ switch:
     name: "Button lock"
     id: button_lock
     optimistic: true
-    restore_state: true
     restore_mode: ALWAYS_OFF
 
 sensor:


### PR DESCRIPTION
Trying to use this config with `esphome` 2023.9.3 gives this error:

```text
  The restore_state option has been removed in 2023.7.0. Use the restore_mode option instead.
```