### PR TITLE
Beca thermostat: add note about the RTL8720xx variants

### DIFF
--- a/src/docs/devices/Beca-Thermostat/index.md
+++ b/src/docs/devices/Beca-Thermostat/index.md
@@ -73,6 +73,11 @@ by desoldering the WB3S and soldering pinout-compatible Espressif modules such
 as the ESP12-E. **This is not required anymore**, as the thermostat has been
 confirmed to work with the BK7231T support introduced with ESPHome 2023.9.0.
 
+Be aware that the dual-band variants, such as the BHT-002-GCLW**DB**, ship with
+the Tuya WBR3D module, utilizing the Realtek RTL8720DN chip. It's important to
+note that as of late 2023, LibreTiny, and therefore ESPHome, do not offer
+support for this particular chipset.
+
 ## Flashing
 
 It is often possible to use [tuya-convert](/guides/tuya-convert/) for the


### PR DESCRIPTION
As a tiny follow up on PR #529, merged last week (thanks!), I went ahead and bought a BHT-002-GCLW**DB**, featuring "WiFi dual-band support". This is accomplished by utilizing a Tuya WBR3D, which is based on the Realtek RTL8720DN. LibreTiny does not yet support this chip -- https://github.com/libretiny-eu/libretiny/issues/44 has some relevant context.

Add a note to the documentation, so that users are aware and hopefully avoid these variants.