### PR TITLE
Update status led gpio, function and some comments

### DIFF
--- a/src/docs/devices/Brilliant-Smart-Plug/index.md
+++ b/src/docs/devices/Brilliant-Smart-Plug/index.md
@@ -12,71 +12,85 @@ board: esp8266
 | ------ | ---------------------------- |
 | GPIO5  | Relay                        |
 | GPIO14 | Push Button (Inverted: true) |
-| GPIO13 | Red LED (Inverted: true)     |
+| GPIO12 | Red LED (Inverted: true)     |
 
 ## Basic Configuration
 
 ```yaml
-# Basic Config
-# https://www.brilliantsmart.com.au/smart-products/electrical/wifi-plug-with-usb-charger/
+# https://brilliantlighting.com.au/product/smart-wifi-plug-with-usb-charger-8e7c49
+# Brilliant Smart WiFi Plug with USB charger model: 20676/05
+substitutions:
+  devicename: brilliant-1
+  friendlyname: brilliant_1
+
 esphome:
-  name: brilliant_1
+  name: $devicename
+  friendly_name: $friendlyname
   platform: ESP8266
   board: esp01_1m
   board_flash_mode: dout
 
 wifi:
-  ssid: "ssid"
-  password: "password"
+  ssid: !secret my_wifi_ssid
+  password: !secret my_wifi_pwd
   ap:
-    ssid: "brilliant1"
-    password: "ap_password"
-  domain: ".xxxxx.com"
-
-logger:
-
-web_server:
+    ssid: $devicename
+    password: !secret ap_password
 
 api:
   encryption:
     key: !secret api_encryption_key
 
 ota:
-  password: "ota_password"
+  password: !secret ota_password
 
+logger:
+
+web_server:
+
+sensor:
+  - platform: wifi_signal
+    name: $devicename WiFi Signal
+    update_interval: 60s
+
+#------------------------------------
+# Button toggles relay
 binary_sensor:
   - platform: gpio
     pin:
       number: GPIO14
       mode: INPUT_PULLUP
       inverted: True
-    name: "Brilliant_1 Button"
+    name: $friendlyname Button
     on_press:
       - switch.toggle: relay
   - platform: status
-    name: "Brilliant_1 Status"
+    name: $friendlyname Status
 
-sensor:
-  - platform: wifi_signal
-    name: "Brilliant 1 WiFi Signal"
-    update_interval: 60s
-
+# Relay output of plug
 switch:
   - platform: gpio
-    name: "Brilliant_1 Relay"
+    name: Relay
     pin: GPIO5
-    id: "relay"
-  - platform: restart
-    name: "Brilliant_1 Restart"
-output:
-  - platform: esp8266_pwm
-    id: brilliant_1_red_led
-    pin:
-      number: GPIO13
-      inverted: True
+    id: relay
+    on_turn_on:
+    - output.turn_off: light_output #turn status led OFF so LED is blue when relay is on 
+    on_turn_off:
+    - output.turn_on: light_output #turn status led ON so LED is red when relay==off && status==ok
 
+# Red LED status when module initialising and connecting
 light:
-  - platform: monochromatic
-    name: "Brilliant_1  LED"
-    output: brilliant_1_red_led
+  - platform: status_led # status_led type can be overwritten by output if status==ok.
+    name: status
+    internal: True #don't expose a user controllable switch to HomeAssistant interface
+    pin:
+      number: GPIO12
+      inverted: False
+
+output:
+  - id: light_output
+    platform: gpio
+    pin:
+      number: GPIO12
+      inverted: True
 ```

--- a/src/docs/devices/Brilliant-Smart-Plug/index.md
+++ b/src/docs/devices/Brilliant-Smart-Plug/index.md
@@ -74,7 +74,7 @@ switch:
     pin: GPIO5
     id: relay
     on_turn_on:
-    - output.turn_off: light_output #turn status led OFF so LED is blue when relay is on 
+    - output.turn_off: light_output #turn status led OFF so LED is blue when relay is on
     on_turn_off:
     - output.turn_on: light_output #turn status led ON so LED is red when relay==off && status==ok
 


### PR DESCRIPTION
Changed led output pin from GPIO13 to GPIO12 because GPIO 13 didn't do anything on my devices but GPIO12 does.
Update url at the top to the currently correct one (2023-10-22) Added device model number
Used substitutions for device name and !secret for more parameters.
Changed status "red_led" functionality to match original firmware behaviour. LED behaviour should be:
 - Blinking red when initializing or not ok
 - Solid red when connected, status ok and relay off
 - Solid blue when relay on and status ok
Added basic comments about what sections and lines are doing for noobs like me to understand.