### PR TITLE
Update to version that uses wb2s chip and tuya-cloudcutter instead of…

### DIFF
--- a/src/docs/devices/Deta-6294HA/index.md
+++ b/src/docs/devices/Deta-6294HA/index.md
@@ -9,7 +9,7 @@ board: wb2s
 
 ## General Notes
 
-The [DETA 6294HA Outdoor Double Powerpoint](https://detaelectrical.com.au/product/deta-grid-connect-smart-outdoor-double-powerpoint/) is supplied with a WB2S module that ~~requires replacing with a ESP-02S or equivalent module~~ can be reprogrammed to tinytuya OTA using tuya-cloudcutter.
+The [DETA 6294HA Outdoor Double Powerpoint](https://detaelectrical.com.au/product/deta-grid-connect-smart-outdoor-double-powerpoint/) is supplied with a WB2S module that ~~requires replacing with a ESP-02S or equivalent module~~ can be reprogrammed to LibreTiny OTA using tuya-cloudcutter.
 My units had MCU version 1.1.3 but the deta-6920ha-double-touch-outlet-v1.1.4 profile worked to flash kickstart firmware.
 
 Power measuring uses a HLW8032, CSE7766 compatible protocol at 4800 baud. As RX1 pin is used, you must program the device before installing module.

--- a/src/docs/devices/Deta-6294HA/index.md
+++ b/src/docs/devices/Deta-6294HA/index.md
@@ -9,7 +9,7 @@ board: wb2s
 ## General Notes
 
 The [DETA 6294HA Outdoor Double Powerpoint](https://detaelectrical.com.au/product/deta-grid-connect-smart-outdoor-double-powerpoint/) is supplied with a WB2S module that ~~requires replacing with a ESP-02S or equivalent module~~ can be reprogrammed to LibreTiny OTA using [tuya-cloudcutter](https://github.com/tuya-cloudcutter/tuya-cloudcutter).
-My units had MCU version 1.1.3 but the deta-6920ha-double-touch-outlet-v1.1.4 profile worked to flash kickstart firmware.
+The deta-6920ha-double-touch-outlet-v1.1.4 profile worked to flash kickstart firmware.
 
 Power measuring uses a HLW8032, CSE7766 compatible protocol at 4800 baud. As RX1 pin is used, you must program the device before installing module.
 

--- a/src/docs/devices/Deta-6294HA/index.md
+++ b/src/docs/devices/Deta-6294HA/index.md
@@ -3,13 +3,12 @@ title: DETA Outdoor Double Powerpoint (6294HA)
 date-published: 2023-10-24
 type: socket
 standard: au
-~~board: esp8266~~
 board: wb2s
 ---
 
 ## General Notes
 
-The [DETA 6294HA Outdoor Double Powerpoint](https://detaelectrical.com.au/product/deta-grid-connect-smart-outdoor-double-powerpoint/) is supplied with a WB2S module that ~~requires replacing with a ESP-02S or equivalent module~~ can be reprogrammed to LibreTiny OTA using tuya-cloudcutter.
+The [DETA 6294HA Outdoor Double Powerpoint](https://detaelectrical.com.au/product/deta-grid-connect-smart-outdoor-double-powerpoint/) is supplied with a WB2S module that ~~requires replacing with a ESP-02S or equivalent module~~ can be reprogrammed to LibreTiny OTA using [tuya-cloudcutter](https://github.com/tuya-cloudcutter/tuya-cloudcutter).
 My units had MCU version 1.1.3 but the deta-6920ha-double-touch-outlet-v1.1.4 profile worked to flash kickstart firmware.
 
 Power measuring uses a HLW8032, CSE7766 compatible protocol at 4800 baud. As RX1 pin is used, you must program the device before installing module.


### PR DESCRIPTION
… replacing the chip

Replacing the wb2s module with an ESP-02S is no longer necessary now that tuya-cloudcutter works with the wb2s module.  Updated url to manufacturer page.
Pin assignments remapped for wb2s module.
More !secret tokens used where applicable.
Added web_server.
Status LED changed to light with platform: status_led and NOT inverted. Unnecessary relay lambda functions removed for simplification. Removed uptime_sensor for simplification.