### PR TITLE
Fix Sonoff POW Origin 16Amp (POWR316) description

### DIFF
--- a/src/docs/devices/Sonoff-POWR316-16a/index.md
+++ b/src/docs/devices/Sonoff-POWR316-16a/index.md
@@ -13,7 +13,6 @@ board: esp32
 | GPIO00 | Push Button (HIGH = off, LOW = on) |
 | GPIO05 | Wifi_LED                           |
 | GPIO13 | Relay1                             |
-| GPIO14 | TM1621 DA                          |
 | GPIO16 | CSE7766 Rx                         |
 | GPIO18 | Status LED (HIGH = off, LOW = on)  |
 

--- a/src/docs/devices/Sonoff-POWR316-16a/index.md
+++ b/src/docs/devices/Sonoff-POWR316-16a/index.md
@@ -123,9 +123,4 @@ switch:
     name: "${dev_nice_name} - Relay Switch"
     pin: GPIO13
     id: relay
-
-status_led:
-  pin:
-    number: GPIO16
-    inverted: yes
 ```


### PR DESCRIPTION
Changes:
- this model has no display so pin GPIO14 (TM1621 DA) is not used
- GPIO16 is "CSE7766 Rx" pin, status led is set up on pin GPIO05 in other part of basic configuration