### PR TITLE
Shelly Plus 1 Mini documentation update

### DIFF
--- a/src/docs/devices/Shelly-Plus-1-Mini/index.md
+++ b/src/docs/devices/Shelly-Plus-1-Mini/index.md
@@ -83,6 +83,27 @@ binary_sensor:
     filters:
       - delayed_on_off: 5ms
 
+sensor:
+  - platform: ntc
+    sensor: temp_resistance_reading
+    name: "Temperature"
+    unit_of_measurement: "°C"
+    accuracy_decimals: 1
+    icon: "mdi:thermometer"
+    calibration:
+      b_constant: 3350
+      reference_resistance: 10kOhm
+      reference_temperature: 298.15K
+  - platform: resistance
+    id: temp_resistance_reading
+    sensor: temp_analog_reading
+    configuration: DOWNSTREAM
+    resistor: 10kOhm
+  - platform: adc
+    id: temp_analog_reading
+    pin: GPIO3
+    attenuation: 11db
+
 status_led:
   pin:
     number: 0

--- a/src/docs/devices/Shelly-Plus-1-Mini/index.md
+++ b/src/docs/devices/Shelly-Plus-1-Mini/index.md
@@ -86,7 +86,7 @@ binary_sensor:
 sensor:
   - platform: ntc
     sensor: temp_resistance_reading
-    name: "Temperature"
+    name: "${device_name} Temperature"
     unit_of_measurement: "°C"
     accuracy_decimals: 1
     icon: "mdi:thermometer"


### PR DESCRIPTION
I've recently, flashed ESPHome firmware to my shelly plus 1 mini device and tested same temperature sensor configuration example that provided on https://devices.esphome.io/devices/Shelly-Plus-1PM-Mini and it works.