### PR TITLE
Lux sensor off by factor of 10?

### DIFF
--- a/src/docs/devices/Wyze-Outdoor-Plug/index.md
+++ b/src/docs/devices/Wyze-Outdoor-Plug/index.md
@@ -158,8 +158,8 @@ binary_sensor:
     name: ${display_name} daylight
     device_class: light
     lambda: |-
-        // the senor reads 3.1 volts if there is light and 0.5 if there is not light not much inbetween
-        if (id(lux_sensor).state > 2) {
+        // the senor reads .31 volts if there is light and 0.05 if there is not light not much inbetween
+        if (id(lux_sensor).state > .2) {
           // there is daylight outside.
           return true;
         } else {


### PR DESCRIPTION
New to Git and a dabbler, not a programmer...

Just installed this, I'm seeing a lux voltage of .31 max and .14 min in captive portal and log traces.
Seems like the binary light sensor may be off by a factor of 10

Cheers,
Slate