### PR TITLE
Wyze outdoor plug: restore_mode inoperable with pulldown inverted

### DIFF
--- a/src/docs/devices/Wyze-Outdoor-Plug/index.md
+++ b/src/docs/devices/Wyze-Outdoor-Plug/index.md
@@ -141,7 +141,7 @@ binary_sensor:
     pin:
       number: GPIO18
       mode: INPUT_PULLDOWN
-      inverted: True
+      inverted: False
     name: ${display_name} Button1
     on_press:
       - switch.toggle: relay1
@@ -150,7 +150,7 @@ binary_sensor:
     pin:
       number: GPIO17
       mode: INPUT_PULLDOWN
-      inverted: True
+      inverted: False
     name: ${display_name} Button2
     on_press:
       - switch.toggle: relay2


### PR DESCRIPTION
INPUT_PULLDOWN set to `inverted: True` in the examples makes restore_mode set relay state randomly on power up