### PR TITLE
Update wyze plug gpios

### DIFF
--- a/src/docs/devices/Wyze-Plug-2021/index.md
+++ b/src/docs/devices/Wyze-Plug-2021/index.md
@@ -12,6 +12,16 @@ This device is glued together pretty tightly, but can be opened with the applica
 
 ## GPIO Pinout
 
+There are multiple versions of this device, all nominally using the WLPP1 base model number. An earlier version may use these GPIOs:
+
+| Pin    | Function                           |
+| ------ | ---------------------------------- |
+| GPIO15 | Button                             |
+| GPIO16 | Relay                              |
+| GPIO19 | Relay LED                          |
+
+A current device purchased in late 2023 has a model number of WLPP1CFH, which uses a ESP32C3 variant, and uses GPIOs:
+
 | Pin    | Function                           |
 | ------ | ---------------------------------- |
 | GPIO15 | Button                             |

--- a/src/docs/devices/Wyze-Plug-2021/index.md
+++ b/src/docs/devices/Wyze-Plug-2021/index.md
@@ -24,9 +24,9 @@ A current device purchased in late 2023 has a model number of WLPP1CFH, which us
 
 | Pin    | Function                           |
 | ------ | ---------------------------------- |
-| GPIO15 | Button                             |
-| GPIO16 | Relay                              |
-| GPIO19 | Relay LED                          |
+| GPIO10 | Button                             |
+| GPIO0  | Relay                              |
+| GPIO1  | Relay LED                          |
 
 ## Basic Configuration
 


### PR DESCRIPTION
The Wyze Plug nominally under the WLPP1 model seems to have different variants. One purchased currently in late 2023 appears to be a WLPP1CFH model number, uses a ESP32-C3 variant microcontroller, and different GPIOs.

Not sure what the community's preference is for how we want to document this, but I made a stab at it.