### PR TITLE
Sinilink XY-WFUSB  programming pin pitch correction (1.27mm)

### DIFF
--- a/src/docs/devices/Sinilink-XY-WFUSB-USB-Switch-Relay/index.md
+++ b/src/docs/devices/Sinilink-XY-WFUSB-USB-Switch-Relay/index.md
@@ -17,7 +17,7 @@ for about 5 USD.
 The case can be pried open without too much difficulty. Be careful to keep both
 halves as parallel as possible to not break the pins that hold them together.
 
-Flashing must be done by connecting an FTDI adapter to the 1mm pads close to the
+Flashing must be done by connecting an FTDI adapter to the 1.27 mm pads close to the
 USB female port. Here is the pinout:
 
 ![alt text](wfusb_pinout.jpg "Pinout")


### PR DESCRIPTION
Just a small correction. It says the pins used for programming are 1mm but they are actually 1/20" or 1.27mm