### PR TITLE
Update Sonoff Mini Relay Docs to use "allow_other_uses" for ping 13

### DIFF
--- a/src/docs/devices/Sonoff-Mini-Relay/index.md
+++ b/src/docs/devices/Sonoff-Mini-Relay/index.md
@@ -110,12 +110,15 @@ switch:
 status_led:
   pin:
     number: GPIO13
+    allow_other_uses: true
     inverted: true
 
 output:
   - platform: esp8266_pwm
     id: blue_led
-    pin: GPIO13
+    pin:
+      number: GPIO13
+      allow_other_uses: true
     inverted: True
 
 light:
@@ -213,6 +216,7 @@ binary_sensor:
 status_led:
   pin:
     number: GPIO13
+    allow_other_uses: true
     inverted: true
 
 output:
@@ -223,7 +227,9 @@ output:
   # the 3 lines below control the Blue LED
   - platform: esp8266_pwm
     id: blue_led
-    pin: GPIO13
+    pin:
+      number: GPIO13
+      allow_other_uses: true
     inverted: True
 
 light:


### PR DESCRIPTION
The Sonoff Mini docs specify using pin 13 in two places. In [ESPHome 2022.12 reusing a pin results in an error](https://esphome.io/changelog/2023.12.0.html#pin-reuse-validation). This fixes the config for the Sonoff Mini to ignore this error. I'm honestly not sure if there is a better way to handle this.