### PR TITLE
Fix invalid AirGradient-One yaml

### DIFF
--- a/src/docs/devices/AirGradient-One/index.md
+++ b/src/docs/devices/AirGradient-One/index.md
@@ -358,9 +358,9 @@ output:
     pin: GPIO2
 
 light:
-  color_correct : [50%,50%,50%]
-    # https://esphome.io/components/light/esp32_rmt_led_strip.html
+  # https://esphome.io/components/light/esp32_rmt_led_strip.html
   - platform: esp32_rmt_led_strip
+    color_correct: [50%,50%,50%]
     rgb_order: GRB
     pin: GPIO10  # Pin 16
     num_leds: 11


### PR DESCRIPTION
Was previously getting:

```
INFO ESPHome 2023.12.5
INFO Reading configuration /config/esphome/airgradient.yaml...
ERROR Error while reading config: Invalid YAML syntax:

while parsing a block mapping
  in "<unicode string>", line 345, column 3
did not find expected key
  in "<unicode string>", line 347, column 3
```

Tested this change and things successfully validates now. Not sure if the lights are working as intended, but the sensors are reporting and the display itself looks good.

cc @lilmansplace who added initial support for AirGradient-One in #608