### PR TITLE
Documentation: fix board type for Shelly-Plus-1-mini

### DIFF
--- a/src/docs/devices/Shelly-Plus-1-Mini/index.md
+++ b/src/docs/devices/Shelly-Plus-1-Mini/index.md
@@ -32,7 +32,7 @@ esphome:
     board_build.flash_mode: dio
 
 esp32:
-  board: esp32-c3-devkitm-v1
+  board: esp32-c3-devkitm-1
   framework:
     type: esp-idf
 


### PR DESCRIPTION
The board type contains v1 at the end, while only the 1 is a valid part.