### PR TITLE
S31 - Changes for CSE7766 in 2024.2.0

### DIFF
--- a/src/docs/devices/Sonoff-S31/index.md
+++ b/src/docs/devices/Sonoff-S31/index.md
@@ -69,16 +69,24 @@ sensor:
     current:
       name: "Sonoff S31 Current"
       accuracy_decimals: 1
+      filters:
+        - throttle_average: 60s
     voltage:
       name: "Sonoff S31 Voltage"
       accuracy_decimals: 1
+      filters:
+        - throttle: 60s
     power:
       name: "Sonoff S31 Power"
       accuracy_decimals: 1
       id: my_power
+      filters:
+        - throttle: 60s
   - platform: total_daily_energy
     name: "Sonoff S31 Daily Energy"
     power_id: my_power
+      filters:
+        - throttle: 60s
 
 switch:
   - platform: gpio


### PR DESCRIPTION
Updates from CSE7766 cause flooding, adding filter throttles to make it update every 60s (sanely).