### PR TITLE
Remove `inverted` from Sonoff THR320D relays GPIOs

### DIFF
--- a/src/docs/devices/Sonoff-THR320D/index.md
+++ b/src/docs/devices/Sonoff-THR320D/index.md
@@ -14,18 +14,23 @@ Here's a workaround: <https://community.home-assistant.io/t/bootloop-workaround-
 ## GPIO Pinout
 
 (Source: <https://templates.blakadder.com/sonoff_THR320D.html>)
-Most GPIO are active-low, meaning they're "on" when they're pulled low.
-In ESPHome that's often called "inverted".
+Some GPIO are active-low, meaning they're "on" when they're pulled low. In ESPHome that's often called "inverted".
+The relays GPIO are active-high.
 
 The main relay is bistable/latching, meaning a pulse on pin 1 switches the
 relay ON, and a pulse on pin 2 switches the relay OFF.
+These two pins should never be active at the same time, or the device will become dangerously hot in a few minutes.
+
+Note that until March 2024 there was an error in this page causing a safety issue: 
+The code was considering the relays GPIO as being active-low, when they are actually active-high. So the two main relay pins were stay simultaneously active most of the time, making the device dangerously hot.
+If you copied the old version of the code from here, please remove the ```inverted: True``` line for the relays and update your devices as soon as possible.
 
 | Pin    | Function                                                                  |
 | ------ | ----------------------------------                                        |
 | GPIO0  | Push Button (HIGH = off, LOW = on)                                        |
 | GPIO4  | Small Relay (Dry Contact)                                                 |
-| GPIO19 | Large/Main Relay pin 1, pull low for relay ON                             |
-| GPIO22 | Large/Main Relay pin 2, pull low for relay OFF                            |
+| GPIO19 | Large/Main Relay pin 1, pull high for relay ON                            |
+| GPIO22 | Large/Main Relay pin 2, pull high for relay OFF                           |
 | GPIO5  | Display (TM1621) Data                                                     |
 | GPIO17 | Display (TM1621) CS                                                       |
 | GPIO18 | Display (TM1621) Write                                                    |
@@ -136,7 +141,6 @@ switch:
     internal: True
     pin:
       number: GPIO19
-      inverted: true
     on_turn_on:
       - delay: 500ms
       - switch.turn_off: mainRelayOn
@@ -147,7 +151,6 @@ switch:
     internal: True
     pin:
       number: GPIO22
-      inverted: true
     on_turn_on:
       - delay: 500ms
       - switch.turn_off: mainRelayOff
@@ -158,7 +161,6 @@ switch:
     name: "Dry Contact Relay"
     pin:
       number: GPIO4
-      inverted: true
     on_turn_on:
       - switch.turn_on: ${name}_idk_led
     on_turn_off:
@@ -332,13 +334,11 @@ output:
     id: main_relay_on_output
     pin:
       number: GPIO19
-      inverted: true
 
   - platform: gpio
     id: main_relay_off_output
     pin:
       number: GPIO22
-      inverted: true
 
   - platform: ledc
     id: red_led_output

--- a/src/docs/devices/Sonoff-THR320D/index.md
+++ b/src/docs/devices/Sonoff-THR320D/index.md
@@ -21,7 +21,7 @@ The main relay is bistable/latching, meaning a pulse on pin 1 switches the
 relay ON, and a pulse on pin 2 switches the relay OFF.
 These two pins should never be active at the same time, or the device will become dangerously hot in a few minutes.
 
-Note that until March 2024 there was an error in this page causing a safety issue: 
+Note that until March 2024 there was an error in this page causing a safety issue:
 The code was considering the relays GPIO as being active-low, when they are actually active-high. So the two main relay pins were stay simultaneously active most of the time, making the device dangerously hot.
 If you copied the old version of the code from here, please remove the ```inverted: True``` line for the relays and update your devices as soon as possible.
 


### PR DESCRIPTION
Hi all,
I've found an error in the code for the Sonoff THR320D that is causing the device to become very hot.
The relays GPIOs were considered as active-low (`inverted: True`), but they are actually active-high.
This was probably making the bistable main relay coil to overheat or the drivers to short circuit or something like that, making the whole device too hot to touch.
After the fix, the device doesn't get hot at all, so I'm sure that was the issue.
You can check here that relays GPIOs are actually active-high: https://templates.blakadder.com/sonoff_THR320D.html 

I think this should be fixed as soon as possible, because the device was getting so hot that it could be a fire hazard!