### PR TITLE
Update ESP-12F_Relay_X4 documentation to address issues with GPIO16 & relay1

### DIFF
--- a/src/docs/devices/ESP-12F-Relay-X4/index.md
+++ b/src/docs/devices/ESP-12F-Relay-X4/index.md
@@ -20,7 +20,7 @@ Search for more: https://www.aliexpress.com/wholesale?SearchText=esp-12f+ac90-25
 
 A more detailed manual: https://templates.blakadder.com/assets/ESP12F_Relay_X4.pdf
 
-The board uses GPIO16 for RXD so it will always be briefly be powered on at boot, unforetunately this is also the pin the board is setup to use for relay1. If this brief power-on isn't an issue, you can continue to use GPIO16 or you can run a longer jumper over to a pin such as GPIO15. 
+The board uses GPIO16 for RXD so it will always be briefly be powered on at boot, unforetunately this is also the pin the board is setup to use for relay1. If this brief power-on isn't an issue, you can continue to use GPIO16 or you can run a longer jumper over to a pin such as GPIO15.
 
 ## GPIO Pinout
 

--- a/src/docs/devices/ESP-12F-Relay-X4/index.md
+++ b/src/docs/devices/ESP-12F-Relay-X4/index.md
@@ -20,6 +20,8 @@ Search for more: https://www.aliexpress.com/wholesale?SearchText=esp-12f+ac90-25
 
 A more detailed manual: https://templates.blakadder.com/assets/ESP12F_Relay_X4.pdf
 
+The board uses GPIO16 for RXD so it will always be briefly be powered on at boot, unforetunately this is also the pin the board is setup to use for relay1. If this brief power-on isn't an issue, you can continue to use GPIO16 or you can run a longer jumper over to a pin such as GPIO15. 
+
 ## GPIO Pinout
 
 This board has headers for every GPIO pin on its ESP-12F.
@@ -53,7 +55,8 @@ This board has headers for every GPIO pin on its ESP-12F.
 | ------ | ------------------------------------- | ------ |
 | ADC    | 0V-1V only                            | |
 | EN     | Pulled up                             | |
-| GPIO16 | Use a jumper to RY1 to enable Relay 1 | RY1 |
+| GPIO16 | Use a jumper to RY1 to enable Relay 1 (Warning, see note above about power-on state) | RY1 |
+| GPIO15 | Optionally, use a longer jumper to RY1 to enable Relay 1 | RY1 |
 | GPIO14 | Use a jumper to RY2 to enable Relay 2 | RY2 |
 | GPIO12 | Use a jumper to RY3 to enable Relay 3 | RY3 |
 | GPIO13 | Use a jumper to RY4 to enable Relay 4 | RY4 |
@@ -75,7 +78,7 @@ status_led:
 # Four relay outputs, exposed as switches in Home Assistant
 switch:
   - platform: gpio
-    pin: GPIO16
+    pin: GPIO16 #or GPIO15 to avoid brief power-on at boot
     name: Relay1
     id: relay1
   - platform: gpio


### PR DESCRIPTION
From my own experiences with this board as well as the "more detailed manual" and this guide here: https://templates.blakadder.com/ESP12F_Relay_X4.html

GPIO16 is used for RXD on this board so it will always be briefly powered on at boot. This may be an issue for someone's use case so it should be addressed in documentation. I have found the suggested use of GPIO15 on the tasmota html page to allow relay1 to function normally.