### PR TITLE
Change energy throttle CSE7766.

### DIFF
--- a/src/docs/devices/Sonoff-S31/index.md
+++ b/src/docs/devices/Sonoff-S31/index.md
@@ -88,7 +88,7 @@ sensor:
       name: "Sonoff S31 Energy"
       accuracy_decimals: 2
       filters:
-        - throttle_average: 60s
+        - throttle: 60s
     apparent_power: #(only available with version 2024.3.0 or greater)
       name: "Sonoff S31 Apparent Power"
       filters:


### PR DESCRIPTION
It is my understanding that since energy is a increasing unit over time, it should not be averaged for accuracy. It will accumulate measurements until the throttle window has expired. I’m also referring to the example of the sensor : https://esphome.io/components/sensor/cse7766