### PR TITLE
Add made for esphome list page

### DIFF
--- a/src/@rocketseat/gatsby-theme-docs/components/Sidebar/index.js
+++ b/src/@rocketseat/gatsby-theme-docs/components/Sidebar/index.js
@@ -78,7 +78,7 @@ export default function Sidebar({ isMenuOpen }) {
               );
             }
 
-            return <Item key={id}>{renderLink(link, label)}</Item>;
+            return <Heading key={id}>{renderLink(link, label)}</Heading>;
           })}
         </List>
       </nav>

--- a/src/components/DeviceLink.js
+++ b/src/components/DeviceLink.js
@@ -55,9 +55,9 @@ export function BoardTag({ board }) {
   );
 }
 
-export function MadeForESPHomeLogo() {
+export function MadeForESPHomeLogo({width}) {
   return (
-    <a href="https://esphome.io/guides/made_for_esphome.html" target="_blank" rel="noreferrer"><img src="/made-for-esphome-black-on-white.svg" width="120px" alt="Made for ESPHome Logo" /></a>
+    <a href="https://esphome.io/guides/made_for_esphome.html" target="_blank" rel="noreferrer"><img src="/made-for-esphome-black-on-white.svg" width={width ? width : "120px"} alt="Made for ESPHome Logo" /></a>
   );
 }
 

--- a/src/components/MadeForESPHomeDevices/madeforesphomedevices.js
+++ b/src/components/MadeForESPHomeDevices/madeforesphomedevices.js
@@ -1,0 +1,53 @@
+import React from "react";
+import { useStaticQuery, graphql } from "gatsby";
+
+import { DeviceLink } from "../DeviceLink";
+
+const MadeForESPHomeDevices = () => {
+  const data = useStaticQuery(graphql`
+    {
+      allMdx(
+        sort: { fields: frontmatter___title }
+        filter: { frontmatter: { made_for_esphome: { eq: true } } }
+      ) {
+        edges {
+          node {
+            id
+            frontmatter {
+              title
+              type
+              standard
+              board
+              made_for_esphome
+            }
+            slug
+          }
+        }
+      }
+    }
+  `);
+  const mapped = data?.allMdx?.edges?.map(({ node }) => {
+    return {
+      id: node.id,
+      slug: node.slug,
+      title: node?.frontmatter?.title,
+      type: node?.frontmatter?.type,
+      board: node?.frontmatter?.board?.toLowerCase(),
+      standard: node?.frontmatter?.standard?.toLowerCase(),
+    };
+  });
+
+  return (
+    <div>
+      <ul>
+        {mapped.map((device) => (
+          <li key={device.id}>
+            <DeviceLink {...device} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default MadeForESPHomeDevices;

--- a/src/config/sidebar.yml
+++ b/src/config/sidebar.yml
@@ -1,5 +1,8 @@
 # Sidebar navigation
 
+- label: 'Made for ESPHome'
+  link: '/made-for-esphome'
+
 - label: 'Device Type'
   items:
     - label: 'Dimmers'

--- a/src/docs/made-for-esphome.mdx
+++ b/src/docs/made-for-esphome.mdx
@@ -1,0 +1,27 @@
+---
+slug: made-for-esphome
+title: "Made for ESPHome"
+---
+
+import MadeForESPHomeDevices from "../components/MadeForESPHomeDevices/madeforesphomedevices";
+import { MadeForESPHomeLogo } from "../components/DeviceLink";
+
+<div>
+  <MadeForESPHomeLogo width="300px" />
+</div>
+
+<p>
+  The following devices are designed to work with ESPHome and are preflashed
+  with the firmware. This means you can easily integrate them into your smart
+  home without any additional setup. Their configurations{" "}
+  <a
+    href="https://esphome.io/guides/made_for_esphome.html"
+    target="_blank"
+    rel="noreferrer"
+  >
+    meet requirements
+  </a>{" "}
+  as set out by the ESPHome project.
+</p>
+
+<MadeForESPHomeDevices />


### PR DESCRIPTION
This adds a generated page with all devices that have `made-for-esphome: True` set in their source. 

Devices adding this flag set to true should be verified with the ESPHome team before merging to ensure only approved devices show in the list.