### PR TITLE
[Relay X1] Add link to enclosure design

### DIFF
--- a/src/docs/devices/ESP32-Relay-X1/index.md
+++ b/src/docs/devices/ESP32-Relay-X1/index.md
@@ -93,6 +93,7 @@ binary_sensor:
         - switch.turn_on: ESP32_relay
 
 ```
+
 ## Enclosure
 
 A 3D-printable case design for this board is available [here](https://github.com/clydebarrow/3dmodels/tree/main/ESP32%20Relay%20x1).

--- a/src/docs/devices/ESP32-Relay-X1/index.md
+++ b/src/docs/devices/ESP32-Relay-X1/index.md
@@ -93,3 +93,6 @@ binary_sensor:
         - switch.turn_on: ESP32_relay
 
 ```
+## Enclosure
+
+A 3D-printable case design for this board is available [here](https://github.com/clydebarrow/3dmodels/tree/main/ESP32%20Relay%20x1).

--- a/src/docs/devices/ESP32-Relay-X1/index.md
+++ b/src/docs/devices/ESP32-Relay-X1/index.md
@@ -91,7 +91,6 @@ binary_sensor:
     on_press:
       then:
         - switch.turn_on: ESP32_relay
-
 ```
 
 ## Enclosure


### PR DESCRIPTION
Add a link to a 3D printable enclosure design for the Relay X1 board.