### PR TITLE
Correct board type for Sonoff Basic R4

### DIFF
--- a/src/docs/devices/Sonoff-BASIC-R4-v1.0/index.md
+++ b/src/docs/devices/Sonoff-BASIC-R4-v1.0/index.md
@@ -39,7 +39,7 @@ esphome:
 
 esp32:
   variant: ESP32C3
-  board: esp32dev
+  board: esp32-c3-devkitm-1
   framework:
     type: esp-idf
     sdkconfig_options:


### PR DESCRIPTION
`esp32dev` is not the correct board type. `esp32-c3-devkitm-1` is the correct board type.

Please reference [ESPHome Issues #5757](https://github.com/esphome/issues/issues/5757)