### PR TITLE
Added Deta GridConnect Single Gang Two-Way Switch 6951HA

### DIFF
--- a/src/docs/devices/DETA-Grid-Connect-Single-Gang-Two-Way-6951HA/index.md
+++ b/src/docs/devices/DETA-Grid-Connect-Single-Gang-Two-Way-6951HA/index.md
@@ -99,7 +99,7 @@ wifi:
   ap:
     ssid: ${devicename}
     password: !secret fallback_password
-    
+
 # Enable logging
 logger:
 


### PR DESCRIPTION
Added documentation for previously undocumented on ESPHome Devices for Deta GridConnect Single Gang Two-Way Switch 6951HA