### PR TITLE
Changed ade7953 to ade7953_i2c

### DIFF
--- a/src/docs/devices/Shelly-25/index.md
+++ b/src/docs/devices/Shelly-25/index.md
@@ -59,7 +59,7 @@ i2c:
   scl: GPIO14
 
 sensor:
-  - platform: ade7953
+  - platform: ade7953_i2c
     irq_pin: GPIO16 # Prevent overheating by setting this
     voltage:
       name: ${devicename} Voltage
@@ -211,7 +211,7 @@ i2c:
   scl: GPIO14
 
 sensor:
-  - platform: ade7953
+  - platform: ade7953_i2c
     irq_pin: GPIO16 # Prevent overheating by setting this
     voltage:
       name: ${devicename} voltage
@@ -379,7 +379,7 @@ i2c:
   scl: GPIO14
 
 sensor:
-  - platform: ade7953
+  - platform: ade7953_i2c
     irq_pin: GPIO16 # Prevent overheating by setting this
     voltage:
       name: ${devicename} Voltage
@@ -539,7 +539,7 @@ i2c:
   scl: GPIO14
 
 sensor:
-  - platform: ade7953
+  - platform: ade7953_i2c
     irq_pin: GPIO16 # Prevent overheating by setting this
     voltage:
       name: ${devicename} voltage


### PR DESCRIPTION
Per the documentation of https://esphome.io/components/sensor/ade7953.html the sensor "ade7953_i2c" has been renamed to "ade7953_i2c".