### PR TITLE
setup_priority-after-axp192

### DIFF
--- a/src/docs/devices/M5Stack-M5StickC-PLUS/index.md
+++ b/src/docs/devices/M5Stack-M5StickC-PLUS/index.md
@@ -162,3 +162,31 @@ microphone:
     pdm: true
     id: mic
 ```
+## Workaround for using devices powered with 5V  on the HY2.0-4P port
+
+The 5V power on the HY2.0-4P is fed by the axp192. Therfore these devices must be initialized some time after the axp192 has started.
+
+```
+i2c:
+   - id: bus_gove
+     sda: GPIO32
+     scl: GPIO33
+     scan: True
+     frequency: 100kHz
+     ## Start some time after the axp192 has powered up. To add additional delay start after wifi.
+     setup_priority: 200
+
+sensor:
+ ## Example: anything connected to "i2c_id: bus_gove" should have a lower setup priority then bus_gove.
+  - platform: scd30
+    setup_priority: 195
+    i2c_id: bus_gove
+    address: 0x61
+    co2:
+      name: "CO2"
+    temperature:
+      name: "Temperature"
+    humidity:
+      name: "Humidity"
+```
+

--- a/src/docs/devices/M5Stack-M5StickC-PLUS/index.md
+++ b/src/docs/devices/M5Stack-M5StickC-PLUS/index.md
@@ -163,27 +163,27 @@ microphone:
     id: mic
 ```
 
-## Workaround for using devices powered with 5V  on the HY2.0-4P port
+## Workaround for using devices powered with 5V on the HY2.0-4P port
 
-The 5V power on the HY2.0-4P is fed by the axp192. Therfore these devices must be initialized some time after the axp192 has started.
+The 5V power on the HY2.0-4P is fed by the axp192. Therefore these devices must be initialized some time after the axp192 has started.
 
 ```yml
 i2c:
-   - id: bus_gove
+   - id: bus_grove
      sda: GPIO32
      scl: GPIO33
      scan: True
      frequency: 100kHz
      ## Start after the axp192 has powered up
-     ## In case an additional delay is needed this component may be helpfull:
+     ## In case an additional delay is needed this component may be helpful:
      ## https://github.com/ssieb/esphome_components/tree/master/components/boot_delay
      setup_priority: 500
 
 sensor:
- ## Example: anything connected to "i2c_id: bus_gove" should have a lower setup priority then bus_gove.
+ ## Example: anything connected to "i2c_id: bus_grove" should have a lower setup priority than bus_grove.
   - platform: scd30
     setup_priority: 490
-    i2c_id: bus_gove
+    i2c_id: bus_grove
     address: 0x61
     co2:
       name: "CO2"

--- a/src/docs/devices/M5Stack-M5StickC-PLUS/index.md
+++ b/src/docs/devices/M5Stack-M5StickC-PLUS/index.md
@@ -162,6 +162,7 @@ microphone:
     pdm: true
     id: mic
 ```
+
 ## Workaround for using devices powered with 5V  on the HY2.0-4P port
 
 The 5V power on the HY2.0-4P is fed by the axp192. Therfore these devices must be initialized some time after the axp192 has started.

--- a/src/docs/devices/M5Stack-M5StickC-PLUS/index.md
+++ b/src/docs/devices/M5Stack-M5StickC-PLUS/index.md
@@ -167,20 +167,22 @@ microphone:
 
 The 5V power on the HY2.0-4P is fed by the axp192. Therfore these devices must be initialized some time after the axp192 has started.
 
-```
+```yml
 i2c:
    - id: bus_gove
      sda: GPIO32
      scl: GPIO33
      scan: True
      frequency: 100kHz
-     ## Start some time after the axp192 has powered up. To add additional delay start after wifi.
-     setup_priority: 200
+     ## Start after the axp192 has powered up
+     ## In case an additional delay is needed this component may be helpfull:
+     ## https://github.com/ssieb/esphome_components/tree/master/components/boot_delay
+     setup_priority: 500
 
 sensor:
  ## Example: anything connected to "i2c_id: bus_gove" should have a lower setup priority then bus_gove.
   - platform: scd30
-    setup_priority: 195
+    setup_priority: 490
     i2c_id: bus_gove
     address: 0x61
     co2:
@@ -190,4 +192,3 @@ sensor:
     humidity:
       name: "Humidity"
 ```
-


### PR DESCRIPTION
There is a timing issue for the using the grove/HY2.0-4P connector as  i2c bus, the axp192 must be running before.