### PR TITLE
Update index.md

### DIFF
--- a/src/docs/devices/ESP32-CAM/index.md
+++ b/src/docs/devices/ESP32-CAM/index.md
@@ -3,7 +3,7 @@ title: Generic ESP32-CAM
 date-published: 2019-10-11
 type: misc
 standard: global
-board: esp32
+board: esp32cam #Changed as per available compatible boards in esphome current (2024.7.0) to have proper capability mapping.
 ---
 
 ## GPIO Pinout


### PR DESCRIPTION
Changed as per available compatible boards in ESPHome current (2024.7.0) to have proper capability mapping. Generic boards and dev boards differ from the IRL Cam board's in GPIO layout for example.