### PR TITLE
MCU instead of board

### DIFF
--- a/src/config/sidebar.yml
+++ b/src/config/sidebar.yml
@@ -35,7 +35,7 @@
       link: '/standards/uk'
     - label: 'US Devices'
       link: '/standards/us'
-- label: Boards
+- label: Microcontroller
   items: 
     - label: 'BK72xx'
       link: '/board/bk72xx'


### PR DESCRIPTION
These are not boards. These are microcontroller types on a plethora of various board types.