### PR TITLE
Update Shelly PM Mini Gen3

### DIFF
--- a/src/docs/devices/Shelly-PM-Mini-Gen3/index.md
+++ b/src/docs/devices/Shelly-PM-Mini-Gen3/index.md
@@ -42,6 +42,7 @@ substitutions:
   platformio_options:
     board_build.flash_mode: dio
 
+
 esphome:
   name: ${device_name}
   friendly_name: ${friendly_name}

--- a/src/docs/devices/Shelly-PM-Mini-Gen3/index.md
+++ b/src/docs/devices/Shelly-PM-Mini-Gen3/index.md
@@ -39,13 +39,12 @@ The UART Pinout is the same as other Shelly Plus Mini.
 substitutions:
   device_name: "pm-mini-gen3"
   friendly_name : "Shelly PM Mini Gen3"
-  platformio_options:
-    board_build.flash_mode: dio
-
 
 esphome:
   name: ${device_name}
   friendly_name: ${friendly_name}
+  platformio_options:
+    board_build.flash_mode: dio
 
 esp32:
   board: esp32-c3-devkitm-1

--- a/src/docs/devices/Shelly-PM-Mini-Gen3/index.md
+++ b/src/docs/devices/Shelly-PM-Mini-Gen3/index.md
@@ -39,6 +39,8 @@ The UART Pinout is the same as other Shelly Plus Mini.
 substitutions:
   device_name: "pm-mini-gen3"
   friendly_name : "Shelly PM Mini Gen3"
+  platformio_options:
+    board_build.flash_mode: dio
 
 esphome:
   name: ${device_name}


### PR DESCRIPTION
Boot loop occurs unless flash_mode: dio is enabled.
This PR adds this to the example yaml.