### PR TITLE
s/11db/12db/

### DIFF
--- a/src/docs/devices/KinCony-KC868-A32/index.md
+++ b/src/docs/devices/KinCony-KC868-A32/index.md
@@ -620,23 +620,23 @@ sensor:
     pin: 39
     name: "analog-1"
     update_interval: 10s
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: adc
     pin: 34
     name: "analog-2"
     update_interval: 10s
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: adc
     pin: 36
     name: "analog-3"
     update_interval: 10s
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: adc
     pin: 35
     name: "analog-4"
     update_interval: 10s
-    attenuation: 11db
+    attenuation: 12db
 ```

--- a/src/docs/devices/KinCony-KC868-A32M/index.md
+++ b/src/docs/devices/KinCony-KC868-A32M/index.md
@@ -337,23 +337,23 @@ sensor:
     pin: 34
     name: "a32m-analog-1"
     update_interval: 10s
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: adc
     pin: 35
     name: "a32m-analog-2"
     update_interval: 10s
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: adc
     pin: 39
     name: "a32m-analog-3"
     update_interval: 10s
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: adc
     pin: 36
     name: "a32m-analog-4"
     update_interval: 10s
-    attenuation: 11db
+    attenuation: 12db
 ```

--- a/src/docs/devices/KinCony-KC868-A64/index.md
+++ b/src/docs/devices/KinCony-KC868-A64/index.md
@@ -1139,23 +1139,23 @@ sensor:
     pin: 39
     name: "a64--analog--1"
     update_interval: 20s
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: adc
     pin: 34
     name: "a64--analog--2"
     update_interval: 20s
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: adc
     pin: 36
     name: "a64--analog--3"
     update_interval: 20s
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: adc
     pin: 35
     name: "a64--analog--4"
     update_interval: 20s
-    attenuation: 11db
+    attenuation: 12db
 ```

--- a/src/docs/devices/KinCony-KC868-AIO/index.md
+++ b/src/docs/devices/KinCony-KC868-AIO/index.md
@@ -408,28 +408,28 @@ sensor:
     pin: 36
     id: adc36
     update_interval: never
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: adc
     name: "aio--AI-17"
     pin: 39
     id: adc39
     update_interval: 5s
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: adc
     pin: 34
     name: "aio--AI-18"
     id: adc34
     update_interval: 5s
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: adc
     pin: 35
     name: "aio--AI-19"
     id: adc35
     update_interval: 5s
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: cd74hc4067
     name: "aio--AI-16"

--- a/src/docs/devices/KinCony-KC868-M16/index.md
+++ b/src/docs/devices/KinCony-KC868-M16/index.md
@@ -71,28 +71,28 @@ sensor:
     pin: 35
     id: adc35
     update_interval: never
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: adc
     name: "m16--AI-1"
     pin: 36
     id: adc36
     update_interval: 15s
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: adc
     pin: 34
     name: "m16--AI-2"
     id: adc34
     update_interval: 15s
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: adc
     pin: 39
     name: "m16--AI-3"
     id: adc39
     update_interval: 15s
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: cd74hc4067
     id: ai1

--- a/src/docs/devices/M5Stack-M5StickC-PLUS2/index.md
+++ b/src/docs/devices/M5Stack-M5StickC-PLUS2/index.md
@@ -72,7 +72,7 @@ ota:
 sensor:
   - platform: adc
     pin: GPIO38
-    attenuation: 11db
+    attenuation: 12db
     update_interval: 60s
     name: "Battery Voltage"
     filters:

--- a/src/docs/devices/Shelly-1-Mini-Gen3/index.md
+++ b/src/docs/devices/Shelly-1-Mini-Gen3/index.md
@@ -96,7 +96,7 @@ sensor:
   - platform: adc
     id: temp_analog_reading
     pin: GPIO3
-    attenuation: 11db
+    attenuation: 12db
 
 output:
   - platform: gpio

--- a/src/docs/devices/Shelly-1PM-Mini-Gen3/index.md
+++ b/src/docs/devices/Shelly-1PM-Mini-Gen3/index.md
@@ -96,7 +96,7 @@ sensor:
   - platform: adc
     id: temp_analog_reading
     pin: GPIO3
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: bl0942
     uart_id: uart_0

--- a/src/docs/devices/Shelly-PM-Mini-Gen3/index.md
+++ b/src/docs/devices/Shelly-PM-Mini-Gen3/index.md
@@ -97,7 +97,7 @@ sensor:
   - platform: adc
     id: temp_analog_reading
     pin: GPIO3
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: bl0942
     uart_id: uart_0

--- a/src/docs/devices/Shelly-Plus-0-10V-Dimmer/index.md
+++ b/src/docs/devices/Shelly-Plus-0-10V-Dimmer/index.md
@@ -139,7 +139,7 @@ sensor:
   - platform: adc
     id: temp_analog_reading
     pin: GPIO32
-    attenuation: 11db
+    attenuation: 12db
 
 
 status_led:

--- a/src/docs/devices/Shelly-Plus-1-Mini/index.md
+++ b/src/docs/devices/Shelly-Plus-1-Mini/index.md
@@ -102,7 +102,7 @@ sensor:
   - platform: adc
     id: temp_analog_reading
     pin: GPIO3
-    attenuation: 11db
+    attenuation: 12db
 
 status_led:
   pin:

--- a/src/docs/devices/Shelly-Plus-1/index.md
+++ b/src/docs/devices/Shelly-Plus-1/index.md
@@ -122,12 +122,12 @@ sensor:
   - platform: adc
     id: temp_analog_reading
     pin: GPIO32
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: adc
     name: "${device_name} Relay Supply Voltage"
     pin: GPIO33
-    attenuation: 11db
+    attenuation: 12db
     filters:
       - multiply: 8
 

--- a/src/docs/devices/Shelly-Plus-1PM-Mini/index.md
+++ b/src/docs/devices/Shelly-Plus-1PM-Mini/index.md
@@ -104,7 +104,7 @@ sensor:
   - platform: adc
     id: temp_analog_reading
     pin: GPIO3
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: bl0942
     uart_id: uart_bus

--- a/src/docs/devices/Shelly-Plus-1PM/index.md
+++ b/src/docs/devices/Shelly-Plus-1PM/index.md
@@ -118,12 +118,12 @@ sensor:
   - platform: adc
     id: temp_analog_reading
     pin: GPIO32
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: adc
     name: "${device_name} Relay Supply Voltage"
     pin: GPIO33
-    attenuation: 11db
+    attenuation: 12db
     filters:
       - multiply: 8
 

--- a/src/docs/devices/Shelly-Plus-2PM/index.md
+++ b/src/docs/devices/Shelly-Plus-2PM/index.md
@@ -184,7 +184,7 @@ sensor:
   - platform: adc
     id: temp_analog_reading
     pin: GPIO35
-    attenuation: 11db
+    attenuation: 12db
     update_interval: 10s
 ```
 
@@ -425,7 +425,7 @@ sensor:
   - platform: adc
     id: temp_analog_reading
     pin: GPIO35
-    attenuation: 11db
+    attenuation: 12db
     update_interval: 60s
 
   #power monitoring
@@ -772,7 +772,7 @@ sensor:
   - platform: adc
     id: temp_analog_reading
     pin: GPIO35
-    attenuation: 11db
+    attenuation: 12db
     update_interval: 10s
 
   #power monitoring

--- a/src/docs/devices/Shelly-Plus-PM-Mini/index.md
+++ b/src/docs/devices/Shelly-Plus-PM-Mini/index.md
@@ -83,7 +83,7 @@ sensor:
   - platform: adc
     id: temp_analog_reading
     pin: GPIO3
-    attenuation: 11db
+    attenuation: 12db
 
   - platform: bl0942
     uart_id: uart_bus

--- a/src/docs/devices/Shelly-Plus-Plug-S/index.md
+++ b/src/docs/devices/Shelly-Plus-Plug-S/index.md
@@ -303,7 +303,7 @@ sensor:
   - platform: adc
     id: temp_analog_reading
     pin: GPIO33
-    attenuation: 11db
+    attenuation: 12db
     update_interval: 10s
 
   - platform: hlw8012

--- a/src/docs/devices/Shelly-i4-Gen3/index.md
+++ b/src/docs/devices/Shelly-i4-Gen3/index.md
@@ -90,7 +90,7 @@ sensor:
   - platform: adc
     id: temp_analog_reading
     pin: GPIO3
-    attenuation: 11db
+    attenuation: 12db
 
 binary_sensor:
   - platform: gpio

--- a/src/docs/devices/Smart-Powermeter/index.md
+++ b/src/docs/devices/Smart-Powermeter/index.md
@@ -83,37 +83,37 @@ sensor:
   - platform: adc
     pin: GPIO1
     id: Input_1
-    attenuation: 11db
+    attenuation: 12db
     update_interval: 1s
 
   - platform: adc
     pin: GPIO2
     id: Input_2
-    attenuation: 11db
+    attenuation: 12db
     update_interval: 1s
 
   - platform: adc
     pin: GPIO3
     id: Input_3
-    attenuation: 11db
+    attenuation: 12db
     update_interval: 1s
 
   - platform: adc
     pin: GPIO4
     id: Input_4
-    attenuation: 11db
+    attenuation: 12db
     update_interval: 1s
 
   - platform: adc
     pin: GPIO5
     id: Input_5
-    attenuation: 11db
+    attenuation: 12db
     update_interval: 1s
 
   - platform: adc
     pin: GPIO6
     id: Input_6
-    attenuation: 11db
+    attenuation: 12db
     update_interval: 1s
 
   - platform: ct_clamp

--- a/src/docs/devices/Wyze-Outdoor-Plug/index.md
+++ b/src/docs/devices/Wyze-Outdoor-Plug/index.md
@@ -107,7 +107,7 @@ sensor:
     id: lux_sensor
     device_class: illuminance
     unit_of_measurement: lx
-    attenuation: 11db
+    attenuation: 12db
   - platform: hlw8012
     sel_pin:
       number: GPIO25


### PR DESCRIPTION
This changes all occurrences of `11db` to `12db`, since `11db` was deprecated and `12db` functions equivalently.