### PR TITLE
Add RTC to M5Stack-dial

### DIFF
--- a/src/docs/devices/M5Stack-Dial/index.md
+++ b/src/docs/devices/M5Stack-Dial/index.md
@@ -22,6 +22,9 @@ M5Stack Dial features an M5StampS3, 8M Flash, 1.28 inch Touchscreen, NFC Reader,
 esphome:
   name: m5stack-dial
   friendly_name: M5Stack Dial
+  on_boot:
+    then:
+      - pcf8563.read_time:
   platformio_options:
     board_build.flash_mode: dio
 
@@ -67,6 +70,18 @@ sensor:
     id: encoder
     pin_a: GPIO40
     pin_b: GPIO41
+
+time:
+  # RTC
+  - platform: pcf8563
+    id: rtctime
+    address: 0x51
+    update_interval: never
+  - platform: homeassistant
+    id: esptime
+    on_time_sync:
+      then:      
+        - pcf8563.write_time:
 
 binary_sensor:
   - platform: gpio

--- a/src/docs/devices/M5Stack-Dial/index.md
+++ b/src/docs/devices/M5Stack-Dial/index.md
@@ -80,7 +80,7 @@ time:
   - platform: homeassistant
     id: esptime
     on_time_sync:
-      then:      
+      then:
         - pcf8563.write_time:
 
 binary_sensor:


### PR DESCRIPTION
M5Stack Dial has a pcf8563 time source. Added it along with a read `on_boot` and a write `on_time_sync` from homeassistant. You could sub out the homeassistant time source for sntp but I have not tested this.