### PR TITLE
Fix wrong relay GPIO for Shelly 1PM Mini Gen3

### DIFF
--- a/src/docs/devices/Shelly-1PM-Mini-Gen3/index.md
+++ b/src/docs/devices/Shelly-1PM-Mini-Gen3/index.md
@@ -143,7 +143,7 @@ status_led:
 output:
   - platform: gpio
     id: "relay_output"
-    pin: 7
+    pin: 5
 
 switch:
   - platform: output


### PR DESCRIPTION
Relay GPIO 7 is TX, GPIO5 is the relay.