### PR TITLE
Fix Broken Apollo PLT-1 GitHub Link

### DIFF
--- a/src/docs/devices/Apollo-Automation-PLT-1/index.md
+++ b/src/docs/devices/Apollo-Automation-PLT-1/index.md
@@ -33,7 +33,7 @@ The Apollo Automation PLT-1 is a plant quality sensor with the following feature
 ## Links
 
 - [Shop](https://apolloautomation.com/products/plt-1-ultimate-plant-sensor-for-home-assistant)
-- [GitHub]([https://](https://github.com/ApolloAutomation/PLT-1))
+- [GitHub](https://github.com/ApolloAutomation/PLT-1)
 - [Wiki](https://wiki.apolloautomation.com/)
 - [Discord](https://dsc.gg/ApolloAutomation)
 - [YouTube](https://www.youtube.com/@ApolloAutomation)


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Fixed Broken Apollo PLT-1 GitHub Link

## Type of changes

- [ ] New device
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [x] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
