### PR TITLE
Sonoff Pow R2: Update and use status_led light component

### DIFF
--- a/src/docs/devices/Sonoff-POW-R2/index.md
+++ b/src/docs/devices/Sonoff-POW-R2/index.md
@@ -23,6 +23,10 @@ difficulty: 3
 
 ## Basic Configuration
 
+As the only controllable LED is the Blue LED, it is configured here to use the
+[`status_led`](/components/light/status_led) light component, which will take over the LED in
+the event of a error/warning state, such as when WiFi is disrupted.
+
 ```yaml
 # Basic Config
 substitutions:
@@ -104,16 +108,11 @@ switch:
     id: relay
     pin: GPIO12
 
-output:
-  - platform: esp8266_pwm
+light:
+  - platform: status_led
+    name: Sonoff POW Blue LED
     id: pow_blue_led
     pin:
-      number: GPIO13
-      inverted: True
-
-light:
-  - platform: monochromatic
-    name: Sonoff POW Blue LED
-    output: pow_blue_led
-    id: led
+        number: GPIO13
+        inverted: True
 ```

--- a/src/docs/devices/Sonoff-POW-R2/index.md
+++ b/src/docs/devices/Sonoff-POW-R2/index.md
@@ -30,11 +30,12 @@ substitutions:
 
 esphome:
   name: "Sonoff POW R2"
-  platform: ESP8266
-  board: esp01_1m
   project:
     name: Sonoff.relay
     version: 'POWR2'
+
+esp8266:
+  board: esp01_1m
 
 logger:
   baud_rate: 0


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes
- Use status_led light component for the blue LED


## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
