### PR TITLE
Fix links to status_led light component

### DIFF
--- a/src/docs/devices/Sonoff-BASIC-R2-v1.4/index.md
+++ b/src/docs/devices/Sonoff-BASIC-R2-v1.4/index.md
@@ -17,8 +17,8 @@ The red side of the LED cannot be individually controlled without modification t
 and serves as the indicator of when the relay is physically enabled.
 
 As the only controllable LED is the Blue LED, it is configured here to use the
-[`status_led`](/components/light/status_led) light component, which will take over the LED in
-the event of a error/warning state, such as when WiFi is disrupted.
+[`status_led` light component](https://esphome.io/components/light/status_led), which will take
+over the LED in the event of a error/warning state, such as when WiFi is disrupted.
 
 ## GPIO Pinout
 

--- a/src/docs/devices/Sonoff-POW-R2/index.md
+++ b/src/docs/devices/Sonoff-POW-R2/index.md
@@ -24,8 +24,8 @@ difficulty: 3
 ## Basic Configuration
 
 As the only controllable LED is the Blue LED, it is configured here to use the
-[`status_led`](/components/light/status_led) light component, which will take over the LED in
-the event of a error/warning state, such as when WiFi is disrupted.
+[`status_led` light component](https://esphome.io/components/light/status_led), which will take
+over the LED in the event of a error/warning state, such as when WiFi is disrupted.
 
 ```yaml
 # Basic Config


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

The links to the status_led light component were using relative paths, but they are hosted on esphome.io, not devices.esphome.io. This PR fixes to use absolute links.


## Type of changes

- [ ] New device
- [ ] Update existing device
- [ ] Removing a device
- [x] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
