### PR TITLE
Add difficulty level 3 (disassembly required) for Sonoff relays

### DIFF
--- a/src/docs/devices/SONOFF-POWCT/index.md
+++ b/src/docs/devices/SONOFF-POWCT/index.md
@@ -4,6 +4,7 @@ date-published: 2024-06-24
 type: relay
 standard: global
 board: esp32
+difficulty: 3
 ---
 
 ## GPIO Pinout

--- a/src/docs/devices/Sonoff-4CH-Pro-R2/index.md
+++ b/src/docs/devices/Sonoff-4CH-Pro-R2/index.md
@@ -4,6 +4,7 @@ date-published: 2019-10-11
 type: relay
 standard: global
 board: esp8266
+difficulty: 3
 ---
 
 ## GPIO Pinout

--- a/src/docs/devices/Sonoff-BASIC-R2-v1.4/index.md
+++ b/src/docs/devices/Sonoff-BASIC-R2-v1.4/index.md
@@ -4,6 +4,7 @@ date-published: 2020-11-22
 type: relay
 standard: global
 board: esp8266
+difficulty: 3
 ---
 
 v1.4 differs from the previous iterations of the Sonoff BASIC in that the two colour LED

--- a/src/docs/devices/Sonoff-BASIC-R4-v1.0/index.md
+++ b/src/docs/devices/Sonoff-BASIC-R4-v1.0/index.md
@@ -4,6 +4,7 @@ date-published: 2023-11-28
 type: relay
 standard: global
 board: esp32
+difficulty: 3
 ---
 
 Sonoff BASIC R4 is upgraded with esp32c3 and a new 'magic mode switch' feature that can be enabled with custom component by @ssieb.

--- a/src/docs/devices/Sonoff-POWR316-16a/index.md
+++ b/src/docs/devices/Sonoff-POWR316-16a/index.md
@@ -4,6 +4,7 @@ date-published: 2013-07-18
 type: relay
 standard: global
 board: esp32
+difficulty: 3
 ---
 
 ## GPIO Pinout


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

All these Sonoff relays require disassembly, but soldering optional (you can simply place dupont into the pins slots and hold them at an angle rather than solder the pin headers).

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
