### PR TITLE
CSE7766 Parity update

### DIFF
--- a/src/docs/devices/Sonoff-S31/index.md
+++ b/src/docs/devices/Sonoff-S31/index.md
@@ -50,6 +50,7 @@ logger:
 uart:
   rx_pin: RX
   baud_rate: 4800
+  parity: EVEN
 
 binary_sensor:
   - platform: gpio


### PR DESCRIPTION
There was an ESPHome change that now requires the parity to be EVEN. This has been addressed in the upstream CSE7766 documentation, just keeping this example code in line.

For reference:
https://github.com/esphome/esphome/pull/7549
Upstream documentation for CSE7766:
https://github.com/esphome/esphome-docs/pull/4308

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes



## Type of changes

- [ ] New device
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [ ] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [ ] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [ ] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
