### PR TITLE
Fix Sonoff-S31

### DIFF
--- a/src/docs/devices/Sonoff-S31/index.md
+++ b/src/docs/devices/Sonoff-S31/index.md
@@ -50,6 +50,7 @@ logger:
 uart:
   rx_pin: RX
   baud_rate: 4800
+  parity: EVEN
 
 binary_sensor:
   - platform: gpio


### PR DESCRIPTION
CSE7766 requires even parity since https://github.com/esphome/esphome/pull/7549. This PR fixes the recipe for the Sonoff-S31, which uses the CSE7766.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes



## Type of changes

- [ ] New device
- [X] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [X] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [X] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [X] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
