### PR TITLE
added status LED for device ESP-12F_Relay_X8

### DIFF
--- a/src/docs/devices/ESP-12F-Relay-X8/index.md
+++ b/src/docs/devices/ESP-12F-Relay-X8/index.md
@@ -31,21 +31,21 @@ This board has headers for every GPIO pin on its ESP-12F.
 | GND   |                                                         |
 | GND   |                                                         |
 
-| Pin    | Comment                                 |
-| ------ | --------------------------------------- |
-| 3V3    | For programming, inject 3.3V power here |
-| 3V3    | For programming, inject 3.3V power here |
-| 5V     |                                         |
-| 5V     |                                         |
-| GND    |                                         |
-| GND    |                                         |
-|        |                                         |
-| GPIO5  | Relay 8                                 |
-| GPIO4  | Relay 7                                 |
-| GPIO0  | Relay 6                                 |
-| GPIO2  | Exposed on board                        |
-| GPIO15 | Relay 5                                 |
-| GND    |                                         |
+| Pin    | Comment                                       |
+| ------ | --------------------------------------------- |
+| 3V3    | For programming, inject 3.3V power here       |
+| 3V3    | For programming, inject 3.3V power here       |
+| 5V     |                                               |
+| 5V     |                                               |
+| GND    |                                               |
+| GND    |                                               |
+|        |                                               |
+| GPIO5  | Relay 8                                       |
+| GPIO4  | Relay 7                                       |
+| GPIO0  | Relay 6                                       |
+| GPIO2  | Exposed on board | (blue) LED on the ESP-12F  |
+| GPIO15 | Relay 5                                       |
+| GND    |                                               |
 
 | Pin    | Comment                                 |
 | ------ | --------------------------------------- |
@@ -66,7 +66,16 @@ esphome:
 
 
 
-# Four relay outputs, exposed as switches in Home Assistant
+# Status LED
+light:
+  - platform: status_led
+    name: "RelayBoard LED"
+    restore_mode: ALWAYS_ON
+    pin:
+      number: GPIO02
+      inverted: True
+
+# 8 relay outputs, exposed as switches in Home Assistant
 switch:
   - platform: gpio
     pin: GPIO16


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes
added status LED (GPIO2)
corrected typo (8 relays, not 4)


## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [x] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
