### PR TITLE
Add i2c to M5Stack-Dial

### DIFF
--- a/src/docs/devices/M5Stack-Dial/index.md
+++ b/src/docs/devices/M5Stack-Dial/index.md
@@ -15,6 +15,17 @@ project-url: https://docs.m5stack.com/en/core/M5Dial
 
 M5Stack Dial features an M5StampS3, 8M Flash, 1.28 inch Touchscreen, NFC Reader, Rotary Encoder and a Buzzer.
 
+## Pin Mapping
+
+When a pin can be used for multiple purposes (e.g. Port A or Port B), they are documented in the table below instead of the example configuration.
+
+| Pin           | Usage         |
+| ------------- | ------------- |
+| GPIO1         | Port B Input  |
+| GPIO2         | Port B Output |
+| GPIO13        | Port A SDA    |
+| GPIO15        | Port A SCL    |
+
 ## Example Configuration
 
 ```yaml
@@ -48,9 +59,6 @@ i2c:
   - id: internal_i2c
     sda: GPIO11
     scl: GPIO12
-  - id: port_a_i2c
-    sda: GPIO13
-    scl: GPIO15
 
 rc522_i2c:
   - id: nfc_reader

--- a/src/docs/devices/M5Stack-Dial/index.md
+++ b/src/docs/devices/M5Stack-Dial/index.md
@@ -78,6 +78,7 @@ time:
   # RTC
   - platform: pcf8563
     id: rtctime
+    i2c_id: internal_i2c
     address: 0x51
     update_interval: never
   - platform: homeassistant

--- a/src/docs/devices/M5Stack-Dial/index.md
+++ b/src/docs/devices/M5Stack-Dial/index.md
@@ -48,6 +48,9 @@ i2c:
   - id: internal_i2c
     sda: GPIO11
     scl: GPIO12
+  - id: port_a_i2c
+    sda: GPIO13
+    scl: GPIO15
 
 rc522_i2c:
   - id: nfc_reader


### PR DESCRIPTION
The M5Stack Dial has a second i2c bus available via a grove connector port, labeled "Port A" on the rear of the device. This change adds support for the second i2c bus per the [documentation](https://docs.m5stack.com/en/core/M5Dial) on the M5Stack site.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes



## Type of changes

- [ ] New device
- [X] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [X] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [X] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [X] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
