### PR TITLE
Necessary Baud Rate changes for Tinxy 4N for successful flashing

### DIFF
--- a/src/docs/devices/Tinxy-4N-Fan-Regulator/index.md
+++ b/src/docs/devices/Tinxy-4N-Fan-Regulator/index.md
@@ -22,6 +22,14 @@ Once the flashing is complete, resolder the W2 and W3 bridges as before, remove 
 ![Tinxy](tinxy3.jpg "W2 and W3 Bridge")
 Knowledge Credit: [Tinxy Forum](https://forum.tinxy.in/t/flashing-custom-firmware-like-tasmota-or-esphome-and-then-restoring-back-to-original/32)
 
+As of 10/2024, Tinxy 4N with fan regulator devices failed flashing with the esphome web flasher because it uses a baud rate of 115200. In order to successfully flash, it is necessary to flash via [esptool.py](https://github.com/espressif/esptool) where the baud rate can be set via scripting. The baud rate was identified to be 460800, if this fails in the future be sure to tinker around with baud rates.
+
+## esptool.py Code
+
+```bash
+python3 -m esptool --port /dev/ttyUSB0 --baud 460800 --before no_reset --after hard_reset write_flash -fm dio 0x00000 firmware.bin
+```bash
+
 ## Esp Code
 
 ```yaml


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes
Necessary Baud Rate changes for Tinxy 4N for successful flashing because flashing fails with esphome web flasher.


## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
