### PR TITLE
Update SW5 instructions to include tuya-cloudcutter

### DIFF
--- a/src/docs/devices/Ghome-SW5/index.md
+++ b/src/docs/devices/Ghome-SW5/index.md
@@ -10,6 +10,26 @@ board: BK7231N
 
 ## Flashing
 
+As of November 2024, there are two methods of flashing this device, using a serial adapter and ltchiptool, or OTA using tuya-cloudcutterflash
+
+### OTA
+
+CAUTION: either install the device properly in the wall before attempting, or have another way of safely powering the device. OTA flashing when the device is powered with mains current can be dangerous
+
+Newer versions of this switch use the BK7231N chip, running 1.0.1 firmware. These devices are able to be flashed using tuya-cloudcutter. 
+
+Install Tuya-cloudcutter, following instructions [here](https://github.com/tuya-cloudcutter/tuya-cloudcutter/tree/main/custom-firmware)
+
+Once the tool is installed, run it with this command:
+
+```sudo ./tuya-cloudcutter.sh -p gosund-sw5-a-v2.1-smart-switch-bk7231n-v1.0.1 -f ESPHome-Kickstart-v23.08.29_bk7231n_app.ota.ug.bin```
+
+FOllow the onscreen instructions to put the device into "slow blink" mode, and then power off/back on when prompted. This will install the ESPHome Kickstart firmware. From there is is possible to OTA install full ESPHome.
+
+
+
+### Serial
+
 The newer versions off amazon US (2024+) of this device came with a Beken BK7231N chip
 
 For newer devices, use a USB to serial adapter, and solder wires onto the pads marked TX, RX, 3.3V and GND.

--- a/src/docs/devices/Ghome-SW5/index.md
+++ b/src/docs/devices/Ghome-SW5/index.md
@@ -16,7 +16,7 @@ As of November 2024, there are two methods of flashing this device, using a seri
 
 CAUTION: either install the device properly in the wall before attempting, or have another way of safely powering the device. OTA flashing when the device is powered with mains current can be dangerous
 
-Newer versions of this switch use the BK7231N chip, running 1.0.1 firmware. These devices are able to be flashed using tuya-cloudcutter. 
+Newer versions of this switch use the BK7231N chip, running 1.0.1 firmware. These devices are able to be flashed using tuya-cloudcutter.
 
 Install Tuya-cloudcutter, following instructions [here](https://github.com/tuya-cloudcutter/tuya-cloudcutter/tree/main/custom-firmware)
 
@@ -25,8 +25,6 @@ Once the tool is installed, run it with this command:
 ```sudo ./tuya-cloudcutter.sh -p gosund-sw5-a-v2.1-smart-switch-bk7231n-v1.0.1 -f ESPHome-Kickstart-v23.08.29_bk7231n_app.ota.ug.bin```
 
 FOllow the onscreen instructions to put the device into "slow blink" mode, and then power off/back on when prompted. This will install the ESPHome Kickstart firmware. From there is is possible to OTA install full ESPHome.
-
-
 
 ### Serial
 


### PR DESCRIPTION
Added instructions for OTA flashing of GHome SW5 using Tuya-cloudcutter

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Added instructions to use Tuya Cloudcutter to OTA flash the switch


## Type of changes

- [ ] New device
- [ X ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [ X ] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [ X ] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [ X ] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
