### PR TITLE
Switch to oscillation_datapoint for Tuya fan

### DIFF
--- a/src/docs/devices/Duux-Whisper-Flex-Smart-Fan-DXCF10/index.md
+++ b/src/docs/devices/Duux-Whisper-Flex-Smart-Fan-DXCF10/index.md
@@ -90,28 +90,9 @@ fan:
     switch_datapoint: 1
     speed_datapoint: 3
     speed_count: 26
+    oscillation_datapoint: 4
 
 switch:
-  - platform: template
-    name: "Oscillate horizontally"
-    icon: mdi:arrow-left-right
-    turn_on_action:
-      then:
-        - select.set:
-            id: "horizontally"
-            option: "on"
-    turn_off_action:
-      then:
-        - select.set:
-            id: "horizontally"
-            option: "off"
-    lambda: |-
-      if (id(horizontally).state == "on") {
-        return true;
-      } else {
-        return false;
-      }
-
   - platform: template
     name: "Oscillate vertically"
     icon: mdi:arrow-up-down
@@ -133,16 +114,6 @@ switch:
       }
 
 select:
-  - platform: "tuya"
-    id: "horizontally"
-    internal: true
-    name: "Oscillate horizontally"
-    enum_datapoint: 4
-    optimistic: true
-    options:
-      0: "off"
-      1: "on"
-
   - platform: "tuya"
     id: "vertically"
     internal: true


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Switching the horizontal oscillation to oscillation_datapoint for Tuya fan. Gets rid of a button and lamba calls. Would be great if Tuya fan also had a vertical oscillation like Tuya climate 😄

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
