### PR TITLE
Add note for Sonoff M5 Matter version that can't be flashed

### DIFF
--- a/src/docs/devices/Sonoff-M5/index.md
+++ b/src/docs/devices/Sonoff-M5/index.md
@@ -8,7 +8,7 @@ difficulty: 3
 ---
 
 ## Notes
-
+- the Matter compatible version of this switch (part numbers ending in W, e.g. M5-2C-86W) is locked and cannot be flashed
 - status LED (blue) in left-most button
 - channel LEDs (red) are dimmable (PWM)
   while relays OFF; 100% bright when ON

--- a/src/docs/devices/Sonoff-M5/index.md
+++ b/src/docs/devices/Sonoff-M5/index.md
@@ -8,6 +8,7 @@ difficulty: 3
 ---
 
 ## Notes
+
 - the Matter compatible version of this switch (part numbers ending in W, e.g. M5-2C-86W) is locked and cannot be flashed
 - status LED (blue) in left-most button
 - channel LEDs (red) are dimmable (PWM)


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes
The Matter compatible version of the Sonoff M5 light switch series can't be flashed, they have a locked bootloader. This PR adds a note in the device's page. 

This is verified by me and **[others](https://community.home-assistant.io/t/flashing-sonoff-switchman-m5-white-matter-version/741099/5)**.


## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
