### PR TITLE
Add 3-relay config for Guition-ESP32-S3-4848S040

### DIFF
--- a/src/docs/devices/Guition-ESP32-S3-4848S040/index.md
+++ b/src/docs/devices/Guition-ESP32-S3-4848S040/index.md
@@ -21,7 +21,7 @@ difficulty: 2
 
 ## Product description
 
-Nice little integrated screen, touch screen, power supply and case with built in relay and 120v/220v power supply.
+Nice little integrated screen, touch screen, power supply and case with built in relay (or three) and 120v/220v power supply.
 
 Avalible on [AliExpress](https://www.aliexpress.com/item/3256806115962222.html) for ~$24.
 
@@ -223,6 +223,14 @@ output:
   - id: internal_relay_1
     platform: gpio
     pin: 40
+
+    # Additional relays (3 relay model)
+  - id: internal_relay_2
+    platform: gpio
+    pin: 2
+  - id: internal_relay_3
+    platform: gpio
+    pin: 1
 
 #-------------------------------------------
 # Internal lights


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

This adds additional relay outputs for the "Three way relay" version of the Guition ESP32-S3-4848S040

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
