### PR TITLE
remove invalid line in config

### DIFF
--- a/src/docs/devices/Feit-PLUG3-WIFI-WP-2-N/index.md
+++ b/src/docs/devices/Feit-PLUG3-WIFI-WP-2-N/index.md
@@ -110,7 +110,6 @@ switch:
     pin: P15
     id: relay
     name: ${friendly_name}
-    output: relay
     on_turn_on:
       - light.turn_on: led_status
     on_turn_off:


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

There was an extra invalid line in the switch config.

## Type of changes

- [ ] New device
- [X] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [ ] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [ ] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [ ] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
