### PR TITLE
Docs example updated for Sinilink XY-WPCE

### DIFF
--- a/src/docs/devices/Sinilink-XY-WPCE/index.md
+++ b/src/docs/devices/Sinilink-XY-WPCE/index.md
@@ -73,6 +73,10 @@ substitutions:
 
 esphome:
   name: ${hostname}
+  # Necessary to prevent relay trigger on ESP restart / wifi loss
+  on_boot:
+    then:
+      - output.turn_off: out_relay
 
   # Shows up in UI
   comment: "Remote power button for ${friendly_name_short}."


### PR DESCRIPTION
Sinilink XY-WPCE brings output high on reboot / loss of wifi triggering inadvertent action on connected PC. Setting it to off on boot fixes this behaviour.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes



## Type of changes

- [ ] New device
- [X] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [X] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [X] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [X] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
