### PR TITLE
Fix errors. Improve LED behaviour : Sonoff POW Origin 16Amp (POWR316)

### DIFF
--- a/src/docs/devices/Sonoff-POWR316-16a/index.md
+++ b/src/docs/devices/Sonoff-POWR316-16a/index.md
@@ -37,6 +37,10 @@ substitutions:
 esphome:
   name: ${device_name}
   friendly_name: ${friendly_name}
+  # optional
+  on_boot:
+    then:
+      - switch.turn_on: relay
   
 esp32:
   board: nodemcu-32s
@@ -47,6 +51,12 @@ wifi:
   ap:
     ssid: ${device_name}
     password: !secret wifi_failover
+  on_connect:
+    then:
+      - light.turn_on: wifi_status_led
+  on_disconnect:
+    then:
+      - light.turn_off: wifi_status_led
 
 captive_portal:
 
@@ -64,29 +74,47 @@ web_server:
 uart:
   rx_pin: GPIO16
   baud_rate: 4800
+  parity: EVEN
   
 sensor:
   - platform: cse7766
-    update_interval: 10s
     current:
       name: ${friendly_name} Current
       id: a_sensor
+      filters:
+        - throttle_average: 30s
     voltage:
       name: ${friendly_name} Voltage
       id: v_sensor
+      filters:
+        - throttle: 30s
     power:
       name: ${friendly_name} Power
       id: w_sensor
-      on_value_range:
-        - above: 4.0
-          then:
-            - light.turn_on: switch_led
-        - below: 3.0
-          then:
-            - light.turn_off: switch_led
+      filters:
+        - throttle_average: 30s
     energy:
       name: ${friendly_name} Energy
       id: wh_sensor
+      filters:
+        - throttle_average: 30s
+
+  - platform: template
+    name: $friendly_name ESP32 Internal Temp
+    device_class: temperature
+    unit_of_measurement: °C
+    id: esp32_temp
+    lambda: return temperatureRead();
+    update_interval: 600s
+
+  - platform: wifi_signal
+    name: "WiFi Signal"
+    update_interval: 600s
+
+text_sensor:
+  - platform: wifi_info
+    ip_address:
+      name: "IP Address"
 
 output:
   - platform: ledc
@@ -100,6 +128,7 @@ light:
     id: switch_led
     output: led
     internal: True
+    default_transition_length: 0s
   - platform: status_led
     id: wifi_status_led
     internal: True
@@ -115,13 +144,19 @@ binary_sensor:
         input: true
         pullup: true
       inverted: true
-    name: "${dev_nice_name} - Button"
+    name: "${friendly_name} - Button"
     on_press:
       - switch.toggle: relay
 
 switch:
   - platform: gpio
-    name: "${dev_nice_name} - Relay Switch"
+    name: "${friendly_name} - Relay Switch"
     pin: GPIO13
     id: relay
+    on_turn_on: 
+      then:
+        - light.turn_on: switch_led
+    on_turn_off: 
+      then:
+        - light.turn_off: switch_led
 ```

--- a/src/docs/devices/Sonoff-POWR316-16a/index.md
+++ b/src/docs/devices/Sonoff-POWR316-16a/index.md
@@ -153,10 +153,10 @@ switch:
     name: "${friendly_name} - Relay Switch"
     pin: GPIO13
     id: relay
-    on_turn_on: 
+    on_turn_on:
       then:
         - light.turn_on: switch_led
-    on_turn_off: 
+    on_turn_off:
       then:
         - light.turn_off: switch_led
 ```


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

- Fixed WiFi LED behaviour
- Add required `parity: EVEN` on `uart`.
- Remove unsupported `update_interval: 10s` on `platform: cse7766`.
- Removed references to undefined substitution `dev_nice_name`.
- Setup standard power LED illuminates when relay in turned on behaviour.
- Added internal temp, WiFi signal and IP reporting.

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
