### PR TITLE
Fixing broken links in Xiaomi-Mijia-Bedside-Lamp-2/index.md

### DIFF
--- a/src/docs/devices/Xiaomi-Mijia-Bedside-Lamp-2/index.md
+++ b/src/docs/devices/Xiaomi-Mijia-Bedside-Lamp-2/index.md
@@ -50,12 +50,12 @@ An [external component](https://github.com/mmakaay/esphome-xiaomi_bslamp2) was c
 All information on how to build, flash and configure the ESPHome firmware can be found in the component repository. Here are some useful links:
 
 * [The GitHub repo](https://github.com/mmakaay/esphome-xiaomi_bslamp2)
-* [Documentation index](https://github.com/mmakaay/esphome-xiaomi_bslamp2/blob/main/README.md)
-* [Quick start guide](https://github.com/mmakaay/esphome-xiaomi_bslamp2/blob/main/README.md#quick-start-guide)
-* [Flashing guide](https://github.com/mmakaay/esphome-xiaomi_bslamp2/blob/main/doc/flashing.md)
-* [Configuration guide](https://github.com/mmakaay/esphome-xiaomi_bslamp2/blob/main/doc/configuration.md)
-  and an [example.yaml](https://github.com/mmakaay/esphome-xiaomi_bslamp2/blob/main/example.yaml)
-* [Technical details](https://github.com/mmakaay/esphome-xiaomi_bslamp2/blob/main/doc/technical_details.md)
+* [Documentation index](https://github.com/mmakaay/esphome-xiaomi_bslamp2/blob/dev/README.md)
+* [Quick start guide](https://github.com/mmakaay/esphome-xiaomi_bslamp2/blob/dev/README.md#quick-start-guide)
+* [Flashing guide](https://github.com/mmakaay/esphome-xiaomi_bslamp2/blob/dev/doc/flashing.md)
+* [Configuration guide](https://github.com/mmakaay/esphome-xiaomi_bslamp2/blob/dev/doc/configuration.md)
+  and an [example.yaml](https://github.com/mmakaay/esphome-xiaomi_bslamp2/blob/dev/example.yaml)
+* [Technical details](https://github.com/mmakaay/esphome-xiaomi_bslamp2/blob/dev/doc/technical_details.md)
 
 ## Contacting the author
 


### PR DESCRIPTION
The linked repository https://github.com/mmakaay/esphome-xiaomi_bslamp2 no longer has a "main" branch; links changed to refer to the "dev" branch", preferring this over one of the "release/" branches. OK?

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes



## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [ ] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [ ] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
