### PR TITLE
Shelly-Plus-Plug-S: example bug fix

### DIFF
--- a/src/docs/devices/Shelly-Plus-Plug-S/index.md
+++ b/src/docs/devices/Shelly-Plus-Plug-S/index.md
@@ -303,7 +303,7 @@ sensor:
   - platform: adc
     id: temp_analog_reading
     pin: GPIO33
-    attenuation: 12db
+    attenuation: 11db
     update_interval: 10s
 
   - platform: hlw8012


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes
Attenuation can only be set to the following values: 0db, 2.5db, 6db, 11db. Template/example changed to '11db' to avoid compiling error.


## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [ ] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [ ] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [ ] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
