### PR TITLE
ESP32E-Relay-X8: Copy relay GPIOs to pin listing.

### DIFF
--- a/src/docs/devices/ESP32E-Relay-X8/index.md
+++ b/src/docs/devices/ESP32E-Relay-X8/index.md
@@ -22,14 +22,23 @@ I bought it from: https://www.aliexpress.us/item/3256802045374301.html
 
 This board has headers for every GPIO pin on its ESP32.
 
-| Pin   | Comment                                                 |
-| ----- | ------------------------------------------------------- |
-| 5V    | Do not use 5V for programming                           |
-| TX    | Exposed on board 3.3V level!                            |
-| RX    | Exposed on board 3.3V level!                            |
-| GND   |                                                         |
-| GND   |                                                         |
-| GPIO0 | 3.3V level! (Connected to a push button for programing) |
+| Pin    | Comment                                                  |
+| ------ | -------------------------------------------------------- |
+| 5V     | Do not use 5V for programming                            |
+| TX     | Exposed on board 3.3V level!                             |
+| RX     | Exposed on board 3.3V level!                             |
+| GND    |                                                          |
+| GND    |                                                          |
+| GPIO0  | 3.3V level! (Connected to a push button for programing)  |
+| GPIO23 | On-board general purpose LED                             |
+| GPIO32 | Relay 1                                                  |
+| GPIO33 | Relay 2                                                  |
+| GPIO25 | Relay 3                                                  |
+| GPIO26 | Relay 4                                                  |
+| GPIO27 | Relay 5                                                  |
+| GPIO14 | Relay 6                                                  |
+| GPIO12 | Relay 7                                                  |
+| GPIO13 | Relay 8                                                  |
 
 ## Basic Config
 


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes



## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
