### PR TITLE
Remove rmt_channel as it was removed from IDF

### DIFF
--- a/src/docs/devices/Shelly-Plus-Plug-S/index.md
+++ b/src/docs/devices/Shelly-Plus-Plug-S/index.md
@@ -217,7 +217,6 @@ light:
 
   - platform: esp32_rmt_led_strip
     rgb_order: GRB
-    rmt_channel: 0
     chipset: ws2812
     pin: GPIO25
     num_leds: 2
@@ -227,7 +226,6 @@ light:
     restore_mode: ALWAYS_OFF
   - platform: esp32_rmt_led_strip
     rgb_order: GRB
-    rmt_channel: 1
     chipset: ws2812
     pin: GPIO26
     num_leds: 2


### PR DESCRIPTION
See https://github.com/esphome/esphome/pull/7770#issuecomment-2555924247

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes



## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
