### PR TITLE
Update index.md

### DIFF
--- a/src/docs/devices/KinCony-KC868-A16/index.md
+++ b/src/docs/devices/KinCony-KC868-A16/index.md
@@ -90,12 +90,16 @@ i2c:
 pcf8574:
   - id: inputs_1_8
     address: 0x22
+    pcf8575: false
   - id: inputs_9_16
     address: 0x21
+    pcf8575: false
   - id: outputs_1_8
     address: 0x24
+    pcf8575: false
   - id: outputs_9_16
     address: 0x25
+    pcf8575: false
 
 binary_sensor:
   - platform: gpio


### PR DESCRIPTION
Added     pcf8575: false to the pcf8574 config based on ESPhome documentation.  

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes



## Type of changes

- [ ] New device
- [x ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [ x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [ x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [ x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
