### PR TITLE
Updates to the Sonoff S31 basic config

### DIFF
--- a/src/docs/devices/Sonoff-S31/index.md
+++ b/src/docs/devices/Sonoff-S31/index.md
@@ -37,7 +37,7 @@ wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
 
-# Remove the following line if you're not using Home Assistsant or your switch will restart every now and again
+# Remove the following line if you're not using Home Assistant or your switch will restart every now and again
 api:
 
 ota:

--- a/src/docs/devices/Sonoff-S31/index.md
+++ b/src/docs/devices/Sonoff-S31/index.md
@@ -41,6 +41,7 @@ wifi:
 api:
 
 ota:
+  platform: esphome
 
 # Device Specific Config
 

--- a/src/docs/devices/Sonoff-S31/index.md
+++ b/src/docs/devices/Sonoff-S31/index.md
@@ -31,6 +31,7 @@ esphome:
 
 esp8266:
   board: esp12e
+  early_pin_init: false
 
 wifi:
   ssid: !secret wifi_ssid

--- a/src/docs/devices/Sonoff-S31/index.md
+++ b/src/docs/devices/Sonoff-S31/index.md
@@ -28,7 +28,8 @@ You must [remove the cover and use the serial header](https://www.adventurousway
 # Basic Config
 esphome:
   name: sonoff_s31
-  platform: ESP8266
+
+esp8266:
   board: esp12e
 
 wifi:


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes
* Moves platform configuration to the new-style `esp8266` section (from `esphome`)
* Disables `early_pin_init`
    * https://esphome.io/components/esp8266.html recommends disabling this on switches to avoid flickering during updates
* Fixes OTA config when used with modern ESPHome versions
* Fixes typo in comment

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
