### PR TITLE
Sonoff S31 - Powering Relay Coil in Example May Damage UART Adapters

### DIFF
--- a/src/docs/devices/Sonoff-S31/index.md
+++ b/src/docs/devices/Sonoff-S31/index.md
@@ -113,7 +113,7 @@ switch:
     name: "Sonoff S31 Relay"
     pin: GPIO12
     id: relay
-    restore_mode: ALWAYS_OFF # powering Relay may cause damage or instability when programmer supplying Vcc.
+    restore_mode: ALWAYS_OFF # Powering the relay may cause damage or instability when the programmer is supplying Vcc.
 
 time:
   - platform: sntp #(required for total_daily_energy)
@@ -129,3 +129,4 @@ status_led:
 
 - `board: esp12e` is required to enable all 4MB of flash, allowing OTA updates to work after approximately version 2024.4.0
 - `throttle_average: 60s` on cse7766 sensors is highly recommended with version 2024.2.0 or greater.
+- `restore_mode: ALWAYS_OFF` avoids potential damage or instability when using the programmer’s supply.

--- a/src/docs/devices/Sonoff-S31/index.md
+++ b/src/docs/devices/Sonoff-S31/index.md
@@ -113,7 +113,7 @@ switch:
     name: "Sonoff S31 Relay"
     pin: GPIO12
     id: relay
-    restore_mode: ALWAYS_ON
+    restore_mode: ALWAYS_OFF # powering Relay may cause damage or instability when programmer supplying Vcc.
 
 time:
   - platform: sntp #(required for total_daily_energy)


### PR DESCRIPTION


<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes
Replaced potentially problematic _restore_mode_ of _ALWAYS_ON_ with _ALWAYS_OFF_. 

Relay Coils are inductive loads and it can be reasonably assumed not all UART adapters will handle the inrush and back EMF appropriately. Changing _restore_mode_ to _ALWAYS_OFF_- avoids an implicit endorsement of a dangerous (to equipment) action when using the example code to do the initial flash. It also maintains the presentation that an option to have relay on by default exists. 


## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
