### PR TITLE
Updated examples with ota platform fixes

### DIFF
--- a/src/docs/devices/Sonoff-M5/index.md
+++ b/src/docs/devices/Sonoff-M5/index.md
@@ -80,7 +80,8 @@ api:
     key: !secret esp_api_key
 
 ota:
-  password: !secret ota_secret
+  - platform: esphome
+    password: !secret ota_secret
 
 sensor:  
   - platform: wifi_signal
@@ -267,8 +268,9 @@ api:
 
 # Enable OTA
 ota:
-  safe_mode: true
-  password: !secret ota_password
+  - platform: esphome
+    safe_mode: true
+    password: !secret ota_password
 
 # Enable WiFi and AP for captive portal
 wifi:


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes
Added the 'platform: esphome' to the ota sections of the examples for the Sonoff M5 Switches.


## Type of changes

- [ ] New device
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [x] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
