### PR TITLE
Added configuration info the Lanbon L8-HD dimmer

### DIFF
--- a/src/docs/devices/lanbon_l8/index.md
+++ b/src/docs/devices/lanbon_l8/index.md
@@ -49,13 +49,20 @@ difficulty: 2
 | GPIO32  | green   |
 | GPIO33  | blue   |
 
-### Relay (3-gang switch model)
+### Relay (L8-HS, 3-gang switch model)
 
 | Pin    | Function      |
 | ------ | ------------- |
 | GPIO12  | relay #1   |
 | GPIO14  | relay #2   |
 | GPIO27  | relay #3   |
+
+### Dimmer (L8-HD, 1-gang switch model)
+
+| Pin    | Function      |
+| ------ | ------------- |
+| GPIO12  | Dimmer Tx   |
+| GPIO27  | Dimmer power relay |
 
 ### How To Flash
 
@@ -82,15 +89,25 @@ output:
   - platform: ledc
     pin: GPIO33
     id: moodBlue
-  - platform: gpio
+  - platform: gpio  ## -HS only
     pin: GPIO12
     id: relay_1
-  - platform: gpio
+  - platform: gpio  ## -HS only
     pin: GPIO14
     id: relay_2
   - platform: gpio
     pin: GPIO27
     id: relay_3
+
+uart:  ## -HD only
+  tx_pin:
+    number: GPIO12
+    inverted: false   # true for EU
+  id: dimmer_tx
+  baud_rate: 115200
+  data_bits: 8
+  parity: NONE
+  stop_bits: 1
 
 light:
   - platform: rgb
@@ -103,6 +120,11 @@ light:
     id: backlight
     output: backlight_pwm
     restore_mode: ALWAYS_ON
+  - platform: lanbon_l8_hd ## -HD only
+    name: "Light"
+    id: local_dimmer
+    restore_mode: ALWAYS_OFF
+    gamma_correct: 0.0
 
 spi:
   clk_pin: GPIO19


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Documentation that goes with PR 8255 in esphome/repo


## Type of changes

- [ ] New device
- [X] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [X] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [X] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [X] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
