### PR TITLE
update eWeLink-SANT-SUD01 basic config

### DIFF
--- a/src/docs/devices/eWeLink-SANT-SUD01/index.md
+++ b/src/docs/devices/eWeLink-SANT-SUD01/index.md
@@ -177,6 +177,8 @@ switch:
     on_turn_off:
     - logger.log: "Switch Turned Off!"
     restore_mode: ALWAYS_OFF
+    turn_on_action:
+      script.execute: regular_press
     platform: template
     #lambda: |-
     #  if (id(power_status_pulses).state > 60.0f) {


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

This change resolves this fatal error when compiling the basic config:
`Either optimistic mode must be enabled, or turn_on_action or turn_off_action must be set, to handle the switch being set.`

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
