### PR TITLE
[A] Remove old style configs

### DIFF
--- a/src/docs/devices/AHRise-AHR-083/index.md
+++ b/src/docs/devices/AHRise-AHR-083/index.md
@@ -32,9 +32,10 @@ substitutions:
 
 esphome:
   name: ${unique_id}
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
-  esp8266_restore_from_flash: true
+  restore_from_flash: true
 
 # WiFi connection
 wifi:

--- a/src/docs/devices/AVATTO-S06-IR-Remote-no-temp-no-humidity/index.md
+++ b/src/docs/devices/AVATTO-S06-IR-Remote-no-temp-no-humidity/index.md
@@ -58,7 +58,8 @@ between the GPIO13 and the RESET pin of the ESP8266 MCU.
 # https://esphome.io/devices/esp8266.html
 esphome:
   name: ir_remote
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
 
 wifi:

--- a/src/docs/devices/AWP02L2/index.md
+++ b/src/docs/devices/AWP02L2/index.md
@@ -39,7 +39,8 @@ substitutions:
 
 esphome:
   name: "${device_name}"
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
 
 wifi:

--- a/src/docs/devices/AWP04L/index.md
+++ b/src/docs/devices/AWP04L/index.md
@@ -35,9 +35,10 @@ substitutions:
 esphome:
   name: ${device_name}
   comment: ${device_description}
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
-  esp8266_restore_from_flash: true #writes each state change to flash for switch or light with restore_mode: RESTORE_DEFAULT_OFF/ON, see https://esphome.io/components/esphome.html#esp8266-restore-from-flash
+  restore_from_flash: true #writes each state change to flash for switch or light with restore_mode: RESTORE_DEFAULT_OFF/ON, see https://esphome.io/components/esphome.html#esp8266-restore-from-flash
 
 wifi:
   ssid: !secret wifi_ssid
@@ -269,9 +270,10 @@ In plug_common.yaml:
 esphome:
   name: ${device_name}
   comment: ${device_description}
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
-  esp8266_restore_from_flash: true #writes each state change to flash for switch or light with restore_mode: RESTORE_DEFAULT_OFF/ON, see https://esphome.io/components/esphome.html#esp8266-restore-from-flash
+  restore_from_flash: true #writes each state change to flash for switch or light with restore_mode: RESTORE_DEFAULT_OFF/ON, see https://esphome.io/components/esphome.html#esp8266-restore-from-flash
 
 wifi:
   ssid: !secret wifi_ssid

--- a/src/docs/devices/Acenx-SOP04-US/index.md
+++ b/src/docs/devices/Acenx-SOP04-US/index.md
@@ -29,7 +29,8 @@ substitutions:
 
 esphome:
   name: "${device_name}"
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
 
 wifi:

--- a/src/docs/devices/AirGradient-DIY/index.md
+++ b/src/docs/devices/AirGradient-DIY/index.md
@@ -18,7 +18,8 @@ If you have multiple sensor boards, you will likely need to make each sensor nam
 ```yaml
 esphome:
   name: airgradient
-  platform: ESP8266
+
+esp8266:
   board: d1_mini
 
 # Enable logging

--- a/src/docs/devices/Aoycocr-X10S-Plug/index.md
+++ b/src/docs/devices/Aoycocr-X10S-Plug/index.md
@@ -38,9 +38,10 @@ substitutions:
 esphome:
   name: ${device_name}
   comment: ${device_description}
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
-  esp8266_restore_from_flash: true #writes each state change to flash for switch or light with restore_mode: RESTORE_DEFAULT_OFF/ON, see https://esphome.io/components/esphome.html#esp8266-restore-from-flash
+  restore_from_flash: true #writes each state change to flash for switch or light with restore_mode: RESTORE_DEFAULT_OFF/ON, see https://esphome.io/components/esphome.html#esp8266-restore-from-flash
 
 wifi:
   ssid: !secret wifi_ssid
@@ -272,7 +273,8 @@ In aoycocr_x10s_common:
 esphome:
   name: ${device_name}
   comment: ${device_description}
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
 
 wifi:

--- a/src/docs/devices/Aoycocr-X13-Outdoor-Plug-2AKBP-X13/index.md
+++ b/src/docs/devices/Aoycocr-X13-Outdoor-Plug-2AKBP-X13/index.md
@@ -69,7 +69,8 @@ substitutions:
 
 esphome:
   name: $devicename
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
   arduino_version: espressif8266@2.6.2
 

--- a/src/docs/devices/Arlec-10m-Smart-Extension-Lead-Plug-AEL10HA/index.md
+++ b/src/docs/devices/Arlec-10m-Smart-Extension-Lead-Plug-AEL10HA/index.md
@@ -39,7 +39,8 @@ substitutions:
 esphome:
   name: ${device_name}
   comment: ${name}
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
 
 wifi:

--- a/src/docs/devices/Arlec-6000HA-Switch/index.md
+++ b/src/docs/devices/Arlec-6000HA-Switch/index.md
@@ -39,7 +39,8 @@ substitutions:
 esphome:
   name: ${device_name}
   comment: ${name}
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
 
 wifi:

--- a/src/docs/devices/Arlec-FL052HA-Security-Flood-Light/index.md
+++ b/src/docs/devices/Arlec-FL052HA-Security-Flood-Light/index.md
@@ -38,7 +38,8 @@ As the flood lights do not have any physical buttons, you will follow the same f
 # Basic Config
 esphome:
   name: fl052ha_flood_light
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
 
 wifi:

--- a/src/docs/devices/Arlec-Grid-Connect-Smart-9W-CCT-LED-Downlight/index.md
+++ b/src/docs/devices/Arlec-Grid-Connect-Smart-9W-CCT-LED-Downlight/index.md
@@ -39,7 +39,8 @@ substitutions:
 
 esphome:
   name: ${device_name}
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
 
 wifi:

--- a/src/docs/devices/Arlec-Grid-Connect-Smart-9W-RGB-CCT-LED-Downlight/index.md
+++ b/src/docs/devices/Arlec-Grid-Connect-Smart-9W-RGB-CCT-LED-Downlight/index.md
@@ -40,7 +40,8 @@ substitutions:
 
 esphome:
   name: ${device_name}
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
 
 wifi:

--- a/src/docs/devices/Arlec-Grid-Connect-Smart-LED-Globe-CWWW/index.md
+++ b/src/docs/devices/Arlec-Grid-Connect-Smart-LED-Globe-CWWW/index.md
@@ -39,7 +39,8 @@ As the LED bulb do not have any physical buttons, by turning the bulb on and off
 # Basic Config
 esphome:
   name: "arlec_GLD112HA"
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
   esp8266_restore_from_flash: true
 

--- a/src/docs/devices/Arlec-Grid-Connect-Smart-LED-RGBWW-10W-GLD322HA/index.md
+++ b/src/docs/devices/Arlec-Grid-Connect-Smart-LED-RGBWW-10W-GLD322HA/index.md
@@ -30,7 +30,8 @@ substitutions:
 
 esphome:
   name: ${device_name}
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
 
 # Enable logging

--- a/src/docs/devices/Arlec-PB89HA-Plug/index.md
+++ b/src/docs/devices/Arlec-PB89HA-Plug/index.md
@@ -41,7 +41,8 @@ substitutions:
 esphome:
   name: ${device_name}
   comment: ${name}
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
 
 wifi:

--- a/src/docs/devices/Arlec-PC189HA-Plug/index.md
+++ b/src/docs/devices/Arlec-PC189HA-Plug/index.md
@@ -40,7 +40,8 @@ substitutions:
 esphome:
   name: ${device_name}
   comment: ${name}
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
 
 wifi:

--- a/src/docs/devices/Arlec-PC288HA-Plug/index.md
+++ b/src/docs/devices/Arlec-PC288HA-Plug/index.md
@@ -26,7 +26,8 @@ substitutions:
 esphome:
   name: ${device_name}
   comment: ${name}
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
 
 wifi:

--- a/src/docs/devices/Arlec-Smart-5m-LED-Strip-Light/index.md
+++ b/src/docs/devices/Arlec-Smart-5m-LED-Strip-Light/index.md
@@ -28,7 +28,8 @@ which comes as a colour changing LED strip with controller and transformer.
 ```yaml
 esphome:
   name: led_strip
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
 
 wifi:

--- a/src/docs/devices/Athom-BR30-Bulb/index.md
+++ b/src/docs/devices/Athom-BR30-Bulb/index.md
@@ -47,11 +47,12 @@ substitutions:
 esphome:
   name: "${device_name}"
   name_add_mac_suffix: true
-  platform: ESP8266
-  board: esp8285
   project:
     name: "${project_name}"
     version: "${project_version}"
+
+esp8266:
+  board: esp8285
 
 api:
 

--- a/src/docs/devices/Athom-E27-15W-Bulb/index.md
+++ b/src/docs/devices/Athom-E27-15W-Bulb/index.md
@@ -47,11 +47,12 @@ substitutions:
 esphome:
   name: "${device_name}"
   name_add_mac_suffix: true
-  platform: ESP8266
-  board: esp8285
   project:
     name: "${project_name}"
     version: "${project_version}"
+
+esp8266:
+  board: esp8285
 
 api:
 

--- a/src/docs/devices/Athom-E27-7W-Bulb/index.md
+++ b/src/docs/devices/Athom-E27-7W-Bulb/index.md
@@ -47,11 +47,12 @@ substitutions:
 esphome:
   name: "${device_name}"
   name_add_mac_suffix: true
-  platform: ESP8266
-  board: esp8285
   project:
     name: "${project_name}"
     version: "${project_version}"
+
+esp8266:
+  board: esp8285
 
 api:
 

--- a/src/docs/devices/Athom-GU10-Bulb/index.md
+++ b/src/docs/devices/Athom-GU10-Bulb/index.md
@@ -47,11 +47,12 @@ substitutions:
 esphome:
   name: "${device_name}"
   name_add_mac_suffix: true
-  platform: ESP8266
-  board: esp8285
   project:
     name: "${project_name}"
     version: "${project_version}"
+
+esp8266:
+  board: esp8285
 
 api:
 

--- a/src/docs/devices/Athom-Smart-Plug-AU/index.md
+++ b/src/docs/devices/Athom-Smart-Plug-AU/index.md
@@ -31,7 +31,8 @@ substitutions:
 
 esphome:
   name: $devicename
-  platform: ESP8266
+
+esp8266:
   board: esp8285
 
 # Enable logging

--- a/src/docs/devices/Athom-Smart-Plug-TP29/index.md
+++ b/src/docs/devices/Athom-Smart-Plug-TP29/index.md
@@ -35,7 +35,8 @@ substitutions:
 
 esphome:
   name: $devicename
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
 
 wifi:

--- a/src/docs/devices/Aukey-SH-PA1-Smart-Plug/index.md
+++ b/src/docs/devices/Aukey-SH-PA1-Smart-Plug/index.md
@@ -23,7 +23,8 @@ board: esp8266
 # Basic Config
 esphome:
   name: mini_tree
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
   platformio_options:
     upload_speed: 115200

--- a/src/docs/devices/Awow-EU3S-Power-Monitoring-Plug/index.md
+++ b/src/docs/devices/Awow-EU3S-Power-Monitoring-Plug/index.md
@@ -41,7 +41,8 @@ substitutions:
 esphome:
   name: ${devicename}
   comment: ${device_description}
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
 
 wifi:

--- a/src/docs/devices/Azpen-Home-With-USB/index.md
+++ b/src/docs/devices/Azpen-Home-With-USB/index.md
@@ -35,7 +35,8 @@ GPIO Descriptions
 # Basic Config
 esphome:
   name: azpenhome
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
 
 wifi:

--- a/src/docs/devices/anoopsyche-jh-g01b1/index.md
+++ b/src/docs/devices/anoopsyche-jh-g01b1/index.md
@@ -27,7 +27,8 @@ substitutions:
 
 esphome:
   name: "${device_name}"
-  platform: ESP8266
+
+esp8266:
   board: esp01_1m
 
 logger:


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Updates examples to remove old style `esphome` block configurations



## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [ ] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [ ] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [ ] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
