### PR TITLE
Add advanced version of config for devices/geiger-counter

### DIFF
--- a/src/docs/devices/geiger-counter/index.md
+++ b/src/docs/devices/geiger-counter/index.md
@@ -95,13 +95,13 @@ sensor:
     pin:
       number: 34
       inverted: True
-      mode: 
-        input: True 
+      mode:
+        input: True
         pullup: False
         pulldown: False
     unit_of_measurement: 'CPS'
     name: 'Ionizing Radiation Power CPS'
-    count_mode: 
+    count_mode:
       rising_edge: DISABLE
       falling_edge: INCREMENT
     accuracy_decimals: 0
@@ -132,7 +132,7 @@ sensor:
     lambda: return id(pulse_sum);
     filters:
       delta: 1
-      
+
   - platform: copy
     source_id: geiger_cpm
     id: ionizing_radiaton_power
@@ -145,6 +145,6 @@ sensor:
       - skip_initial: 15
       - sliding_window_moving_average: # 15 measurements moving average (MA5) here
           window_size: 15
-          send_every: 1      
-      - multiply: 0.0057 # 0.0057 original value or 0.00332 for J305 by IoT-devices tube conversion factor of pulses into uSv/Hour 
+          send_every: 1
+      - multiply: 0.0057 # 0.0057 original value or 0.00332 for J305 by IoT-devices tube conversion factor of pulses into uSv/Hour
 ```

--- a/src/docs/devices/geiger-counter/index.md
+++ b/src/docs/devices/geiger-counter/index.md
@@ -68,3 +68,83 @@ sensor:
       - offset: -12.0 # J305ß Geiger Mueller tube background noise 0.2 pulses / sec x 60 sec = 12 CPM (Counts per Minute)
       - multiply: 0.00812037037037 # Factor: 0.00812037037037
 ```
+
+### Advanced version with every second update including last minute history values
+
+``` yaml
+globals:
+  - id: pulse_history
+    type: int[60]
+    restore_value: no
+    initial_value: "{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}"
+
+  - id: pulse_index
+    type: int
+    restore_value: no
+    initial_value: "0"
+
+  - id: pulse_sum
+    type: int
+    restore_value: no
+    initial_value: "0"
+
+sensor:
+  - platform: pulse_counter
+    id: geiger_cps
+    internal: true
+    pin:
+      number: 34
+      inverted: True
+      mode: 
+        input: True 
+        pullup: False
+        pulldown: False
+    unit_of_measurement: 'CPS'
+    name: 'Ionizing Radiation Power CPS'
+    count_mode: 
+      rising_edge: DISABLE
+      falling_edge: INCREMENT
+    accuracy_decimals: 0
+    update_interval: 1s
+    filters:
+      delta: 1
+    on_raw_value:
+      then:
+        - lambda: |-
+            x=round(x/60); // esphome calculating based on pulses per minute. round required to avoid problem when esphome calc value less than 60 pulses per minute (for example 59.7)
+            id(pulse_sum) -= id(pulse_history)[id(pulse_index)]; // remove old value from overall sum
+            id(pulse_history)[id(pulse_index)] = x; // 'x' is the raw pulse count
+            id(pulse_sum) += x; // add new value to overall sum
+
+            id(pulse_index)++; // change array index where next value will be stores
+            if (id(pulse_index) >= 60) id(pulse_index) = 0; // Reset at 60
+    on_value:
+      then:
+        component.update: geiger_cpm
+
+  - platform: template
+    id: geiger_cpm
+    unit_of_measurement: 'CPM'
+    name: 'Ionizing Radiation Power CPM'
+    accuracy_decimals: 0
+    update_interval: 1s
+    state_class: measurement
+    lambda: return id(pulse_sum);
+    filters:
+      delta: 1
+      
+  - platform: copy
+    source_id: geiger_cpm
+    id: ionizing_radiaton_power
+    unit_of_measurement: 'µSv/h'
+    name: 'Ionizing Radiation Power'
+    state_class: measurement
+    icon: mdi:radioactive
+    accuracy_decimals: 3
+    filters:
+      - skip_initial: 15
+      - sliding_window_moving_average: # 15 measurements moving average (MA5) here
+          window_size: 15
+          send_every: 1      
+      - multiply: 0.0057 # 0.0057 original value or 0.00332 for J305 by IoT-devices tube conversion factor of pulses into uSv/Hour 
+```


### PR DESCRIPTION
Add advanced version of config, which update sensor values once per second and calc dose value depending on historical data during last minute

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes



## Type of changes

- [ ] New device
- [X] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [ ] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [ ] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [ ] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
