### PR TITLE
Added SiloCityLabs dikale filament dryer pcb

### DIFF
--- a/src/docs/devices/SiloCityLabs-Dikale-Filament-Dryer/index.md
+++ b/src/docs/devices/SiloCityLabs-Dikale-Filament-Dryer/index.md
@@ -1,0 +1,42 @@
+---
+title: Dikale Filament Dryer PCB by SiloCityLabs
+date-published: 2025-02-26
+type: misc
+standard: global
+board: esp32
+project-url: https://github.com/SiloCityLabs/esp32-dikale-dryer/blob/main/config.yaml
+made-for-esphome: true
+difficulty: 1
+---
+
+## General Notes
+
+The **Dikale Filament Dryer PCB** by **SiloCityLabs** is a custom PCB designed to replace the original PCB of the Dikale Filament Dryer. The PCB is based on an **ESP32** and can be controlled via **Home Assistant** using the **ESPHome** firmware. The PCB features a **temperature sensor** and a **humidity sensor** to monitor the conditions inside the dryer. The PCB also features a **display** to show the current temperature and humidity, as well as a **button controll** to adjust the settings. 
+
+The PCB is designed to fit inside the Dikale Filament Dryer and can be powered by the original power supply. The PCB can be connected to the original heater and fan, and can be controlled via the original buttons.
+
+## GPIO Pinout
+
+-------------------
+| XIAO Pin | Pin | Function | Description |
+| --- | --- | --- | --- |
+| D0 | GPIO2 | Fan 1 | Original 12v Fan |
+| D1 | GPIO3 | Fan 2 | 4 pin PWM fan |
+| D2 | GPIO4 | 10k NTC | OEM Temp sensor |
+| D3 | GPIO5 | Heat Element | Relay for heating element |
+| D4 | GPIO6 | i2c SDA | Shared Bus |
+| D5 | GPIO7 | i2c SCL | Shared Bus |
+| D9 | GPIO9 | BTN pwr | Power Button |
+| D10 | GPIO10 | BTN mode | Mode Button |
+| D7 | GPIO20 | BTN up | Up Button |
+| D8 | GPIO8 | BTN down | Down Button |
+
+## Basic Config
+
+The latest state of the configuration is available [here](https://github.com/SiloCityLabs/esp32-dikale-dryer/blob/main/config.yaml).
+
+## Pictures
+
+![Picture of ESP32 PCB Front](https://shop.silocitylabs.com/cdn/shop/files/dikale-esp32-pcb-front.jpg "Picture of ESP32 PCB Front")
+![Picture of ESP32 PCB Back](https://shop.silocitylabs.com/cdn/shop/files/dikale-esp32-pcb-back.jpg "Picture of ESP32 PCB Back")
+![Picture of OEM Dikale Unit](https://shop.silocitylabs.com/cdn/shop/files/compatible-dikale-unit.jpg "Picture of OEM Dikale Unit")

--- a/src/docs/devices/SiloCityLabs-Dikale-Filament-Dryer/index.md
+++ b/src/docs/devices/SiloCityLabs-Dikale-Filament-Dryer/index.md
@@ -11,7 +11,7 @@ difficulty: 1
 
 ## General Notes
 
-The **Dikale Filament Dryer PCB** by **SiloCityLabs** is a custom PCB designed to replace the original PCB of the Dikale Filament Dryer. The PCB is based on an **ESP32** and can be controlled via **Home Assistant** using the **ESPHome** firmware. The PCB features a **temperature sensor** and a **humidity sensor** to monitor the conditions inside the dryer. The PCB also features a **display** to show the current temperature and humidity, as well as a **button controll** to adjust the settings. 
+The **Dikale Filament Dryer PCB** by **SiloCityLabs** is a custom PCB designed to replace the original PCB of the Dikale Filament Dryer. The PCB is based on an **ESP32** and can be controlled via **Home Assistant** using the **ESPHome** firmware. The PCB features a **temperature sensor** and a **humidity sensor** to monitor the conditions inside the dryer. The PCB also features a **display** to show the current temperature and humidity, as well as a **button controll** to adjust the settings.
 
 The PCB is designed to fit inside the Dikale Filament Dryer and can be powered by the original power supply. The PCB can be connected to the original heater and fan, and can be controlled via the original buttons.
 


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Initial commit for device creation of SiloCityLabs Filament Dryer PCB.

## Type of changes

- [x] New device
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
