### PR TITLE
Replace old style platform configuration

### DIFF
--- a/src/docs/devices/Sonoff-Mini-Relay/index.md
+++ b/src/docs/devices/Sonoff-Mini-Relay/index.md
@@ -33,7 +33,7 @@ substitutions:
 
 esphome:
   name: ${device_name}
-  platform: ESP8266
+esp8266:
   board: esp8285
 
 wifi:


### PR DESCRIPTION
# Brief description of the changes
Replace old style platform configuration
Related: https://github.com/esphome/esphome/pull/8118


## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [ ] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.
