### PR TITLE
Added SiloCityLabs 4 button Gen 2 airtap pcb

### DIFF
--- a/src/docs/devices/SiloCityLabs-Airtap-t-series-4btn/index.md
+++ b/src/docs/devices/SiloCityLabs-Airtap-t-series-4btn/index.md
@@ -1,0 +1,35 @@
+---
+title: Airtap T Series 4btn PCB by SiloCityLabs
+date-published: 2025-03-02
+type: misc
+standard: global
+board: esp32
+project-url: https://github.com/SiloCityLabs/ac-infinity-esp32/blob/main/Airtap-Tx/Gen-2/esphome-4btn-rev1.yaml
+made-for-esphome: true
+difficulty: 1
+---
+
+## General Notes
+
+The Airtap T Series Custom PCB by SiloCityLabs is a custom PCB designed to replace the OEM PCB in the AC Infinity Airtap T Series. The PCB is designed to fit in the OEM enclosure and provide additional functionality. The PCB is designed to work with ESPHome and is compatible with the ESP32. This board supports the 4 button configuration.
+
+## GPIO Pinout
+
+| ESP32 Pin | Function      | Xiao Pin |
+|-----------|---------------|----------|
+| GPIO2     | PWM           | D0       |
+| GPIO4     | Temp          | D3       |
+| GPIO6     | OLED SDA      | D4       |
+| GPIO7     | OLED SCL      | D5       |
+| GPIO20    | Button Up     | D7       |
+| GPIO8     | Button Down   | D8       |
+| GPIO9     | Button Toggle | D9       |
+| GPIO10    | Button Menu   | D10      |
+
+## Basic Config
+
+The latest state of the configuration is available [here](https://github.com/SiloCityLabs/ac-infinity-esp32/blob/main/Airtap-Tx/Gen-2/esphome-4btn-rev1.yaml).
+
+## Pictures
+
+![Picture of ESP32 PCB](https://shop.silocitylabs.com/cdn/shop/files/Airtap_T_Series_PCB_Front_with_4_buttons.jpg "Picture of PCB")


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Initial commit for device creation of SiloCityLabs Airtap T4 4 button gen 2 pcb.

## Type of changes

- [x] New device
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
