### PR TITLE
Correct typo eps32-c3 > esp32-c3

### DIFF
--- a/src/docs/devices/Athom-Energy-Meter-EM2/index.md
+++ b/src/docs/devices/Athom-Energy-Meter-EM2/index.md
@@ -3,7 +3,7 @@ title: Athom Energy Meter (EM2)
 date-published: 2024-11-01
 type: sensor
 standard: global
-board: eps32-c3
+board: esp32-c3
 project-url: https://github.com/athom-tech/esp32-configs/blob/main/athom-energy-monitor-x2.yaml
 difficulty: 1
 made-for-esphome: true

--- a/src/docs/devices/Athom-Energy-Meter-EM6/index.md
+++ b/src/docs/devices/Athom-Energy-Meter-EM6/index.md
@@ -3,7 +3,7 @@ title: Athom Energy Meter (EM6)
 date-published: 2024-11-01
 type: sensor
 standard: global
-board: eps32-c3
+board: esp32-c3
 project-url: https://github.com/athom-tech/esp32-configs/blob/main/athom-energy-monitor-x6.yaml
 difficulty: 1
 made-for-esphome: true

--- a/src/docs/devices/Athom-Mini-Relay-RS01C3/index.md
+++ b/src/docs/devices/Athom-Mini-Relay-RS01C3/index.md
@@ -3,7 +3,7 @@ title: Athom Mini Relay (RS01C3)
 date-published: 2024-11-01
 type: relay
 standard: global
-board: eps32-c3
+board: esp32-c3
 project-url: https://github.com/athom-tech/esp32-configs/blob/main/athom-mini-relay-v2.yaml
 difficulty: 1
 made-for-esphome: true

--- a/src/docs/devices/Athom-Smart-Plug-PG01V3-EU16A/index.md
+++ b/src/docs/devices/Athom-Smart-Plug-PG01V3-EU16A/index.md
@@ -3,7 +3,7 @@ title: Athom Smart Plug EU V3 (PG01V3-EU16A)
 date-published: 2024-04-25
 type: plug
 standard: eu
-board: eps32-c3
+board: esp32-c3
 project-url: https://github.com/athom-tech/esp32-configs/blob/main/athom-smart-plug.yaml
 difficulty: 1
 made-for-esphome: true

--- a/src/docs/devices/Athom-Smart-Plug-PG03V3-US16A/index.md
+++ b/src/docs/devices/Athom-Smart-Plug-PG03V3-US16A/index.md
@@ -3,7 +3,7 @@ title: Athom Smart Plug US V3 (PG03V3-US16A)
 date-published: 2024-04-25
 type: plug
 standard: us
-board: eps32-c3
+board: esp32-c3
 project-url: https://github.com/athom-tech/esp32-configs/blob/main/athom-smart-plug.yaml
 difficulty: 1
 made-for-esphome: true

--- a/src/docs/devices/Athom-Smart-Plug-PG04V3-UK16A/index.md
+++ b/src/docs/devices/Athom-Smart-Plug-PG04V3-UK16A/index.md
@@ -3,7 +3,7 @@ title: Athom Smart Plug UK V3 (PG04V3-UK16A)
 date-published: 2024-04-25
 type: plug
 standard: uk
-board: eps32-c3
+board: esp32-c3
 project-url: https://github.com/athom-tech/esp32-configs/blob/main/athom-smart-plug.yaml
 difficulty: 1
 made-for-esphome: true

--- a/src/docs/devices/Athom-Smart-Plug-PG05V3-AU10A/index.md
+++ b/src/docs/devices/Athom-Smart-Plug-PG05V3-AU10A/index.md
@@ -3,7 +3,7 @@ title: Athom Smart Plug AU V3 (PG05V3-AU10A)
 date-published: 2024-04-25
 type: plug
 standard: au
-board: eps32-c3
+board: esp32-c3
 project-url: https://github.com/athom-tech/esp32-configs/blob/main/athom-smart-plug.yaml
 difficulty: 1
 made-for-esphome: true


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Several pages contained "eps32-c3", instead of "esp32-c3".

## Type of changes

- [ ] New device
- [ ] Update existing device
- [ ] Removing a device
- [x] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
