### PR TITLE
Simplify DETA 6951ha and 6952ha config and expose as Light components

### DIFF
--- a/src/docs/devices/DETA-Grid-Connect-Single-Gang-Two-Way-6951HA/index.md
+++ b/src/docs/devices/DETA-Grid-Connect-Single-Gang-Two-Way-6951HA/index.md
@@ -5,6 +5,7 @@ type: switch
 standard: au
 board: bk72xx
 made-for-esphome: False
+difficulty: 1
 ---
 
 ## Overview
@@ -24,7 +25,6 @@ As shown on the front of the packet.
 | Variation   | Microcontroller | Board     | Firmware | Flashing methods |
 | ----------- | --------------- | --------- | -------- | ---------------- |
 | Series 1    | Beken BK7231T   | Tuya WB3S | v1.1.5   | Cloudcutter  |
-
 
 ## Setup Guide
 

--- a/src/docs/devices/DETA-Grid-Connect-Single-Gang-Two-Way-6951HA/index.md
+++ b/src/docs/devices/DETA-Grid-Connect-Single-Gang-Two-Way-6951HA/index.md
@@ -5,7 +5,7 @@ type: switch
 standard: au
 board: bk72xx
 made-for-esphome: False
-difficulty: 1
+difficulty: 2
 ---
 
 ## Overview

--- a/src/docs/devices/DETA-Grid-Connect-Single-Gang-Two-Way-6951HA/index.md
+++ b/src/docs/devices/DETA-Grid-Connect-Single-Gang-Two-Way-6951HA/index.md
@@ -1,5 +1,5 @@
 ---
-title: DETA Grid Connect Smart Switch Single Gang Two-Way 6951HA
+title: DETA Grid Connect Smart Switch Single Gang Two-Way (6951HA)
 date-published: 2024-05-21
 type: switch
 standard: au
@@ -10,7 +10,7 @@ difficulty: 2
 
 ## Overview
 
-The DETA [Switch Smart Grid 2 Way 2 Gang (6951HA)](https://www.bunnings.com.au/deta-grid-connect-smart-single-gang-2-way-touch-light-switch_p0346910) is part of the [Grid Connect ecosystem](https://grid-connect.com.au/), and is sold at Bunnings in Australia.
+The DETA [Smart Switch Single Gang Two-Way (6951HA)](https://www.bunnings.com.au/deta-grid-connect-smart-single-gang-2-way-touch-light-switch_p0346910) is part of the [Grid Connect ecosystem](https://grid-connect.com.au/), and is sold at Bunnings in Australia.
 
 Also known as:
 

--- a/src/docs/devices/DETA-Grid-Connect-Single-Gang-Two-Way-6951HA/index.md
+++ b/src/docs/devices/DETA-Grid-Connect-Single-Gang-Two-Way-6951HA/index.md
@@ -4,45 +4,35 @@ date-published: 2024-05-21
 type: switch
 standard: au
 board: bk72xx
+made-for-esphome: False
 ---
-
-## General Notes
-
-The DETA [Smart Single Gang Two Way (6951HA)](https://www.bunnings.com.au/deta-grid-connect-smart-single-gang-2-way-touch-light-switch_p0346910) is made by Arlec as part of the [Grid Connect ecosystem](https://grid-connect.com.au/), and is sold at Bunnings in Australia (unfortunantly at time of writing it isn't sold in New Zealand).
-
-### Series 1
-
-Not labeled as Series 1 as there is no Series 2 at this time.
-These devices are using the Beken BK7231T microcontroller and can be OTA flashed using using Cloudcutter.
-
-The known Tuya firmware on these switches is 1.1.5 and you can use the “Lonsonho” brand “X801A 1-Gang Switch” option in Cloudcutter.
-
-## Getting it up and running
-
-### Cloudcutter
-
-[Cloudcutter](https://github.com/tuya-cloudcutter/tuya-cloudcutter) is a tool designed to simplify the process of flashing Tuya-based devices. It allows you to bypass the need for physically opening the device and swapping out chips. By leveraging the cloud APIs, Cloudcutter enables you to flash the firmware remotely, making it a convenient and less intrusive option. Follow the instructions on the [Cloudcutter GitHub repository](https://github.com/tuya-cloudcutter/tuya-cloudcutter) to use this method for flashing your device.
-
-### Disassembly
-
-If you can't or don't wish to use Cloudcutter, you can flash directly to the outlet with USB to serial adapter.
 
 ## Overview
 
-This guide covers the DETA Smart One Gang / Two-Way Switch, specifically the [Smart Single Switch Two Way (6951HA)]([https://www.bunnings.com.au/deta-smart-single-gang-light-switch-touch-activated-with-grid-connect_p0098811]), which is part of the [Grid Connect ecosystem](https://grid-connect.com.au/). These switches are available at Bunnings stores in Australia (at time of writing, not available in New Zealand).
+The DETA [Switch Smart Grid 2 Way 2 Gang (6951HA)](https://www.bunnings.com.au/deta-grid-connect-smart-single-gang-2-way-touch-light-switch_p0346910) is part of the [Grid Connect ecosystem](https://grid-connect.com.au/), and is sold at Bunnings in Australia.
 
-## Series Information
+Also known as:
 
-### Series 1 - Flashing
+- Smart Single Gang 2 Way Touch Light Switch
+ ([Deta website](https://detaelectrical.com.au/product/deta-grid-connect-smart-single-gang-2-way-touch-light-switch/))
+- Single Gang 2 Way Touch Light Switch ([Grid Connect website](https://grid-connect.com.au/download/6951ha/))
 
-- **Microcontroller**: Beken BK7231T
-- **Flashing Method**: OTA via Cloudcutter
+### Variations
+
+As shown on the front of the packet.
+
+| Variation   | Microcontroller | Board     | Firmware | Flashing methods |
+| ----------- | --------------- | --------- | -------- | ---------------- |
+| Series 1    | Beken BK7231T   | Tuya WB3S | v1.1.5   | Cloudcutter  |
+
 
 ## Setup Guide
 
-### Using Cloudcutter
+### Cloudcutter
 
 [Cloudcutter](https://github.com/tuya-cloudcutter/tuya-cloudcutter) is a tool designed to simplify the flashing process. Follow the [official guide](https://github.com/tuya-cloudcutter/tuya-cloudcutter) for instructions.
+
+You can use the “Lonsonho” brand “X801A 1-Gang Switch” option in Cloudcutter.
 
 ### Manual Flashing
 
@@ -56,15 +46,16 @@ Manual Flashing has not been tested on this specific model, but other models wit
 
 ## GPIO Pinouts
 
-### BK72XX-Based Models
+### Series 1 (WB3S) GPIO Pinouts
+
+_See [Pinouts on WB3S Module Datasheet](https://developer.tuya.com/en/docs/iot/wb3s-module-datasheet?id=K9dx20n6hz5n4#title-5-Interface%20pin%20definition) for more detail_
 
 | Pin    | Function                                                                          |
 | ------ | --------------------------------------------------------------------------------- |
-| P8     | Power Status of actual light, taking into account both switches  _(inverted)_     |
-| P9     | Other members have stated this is the Remote Switch status, but unable to confirm |
-| P14    | Relay,  _(includes LED)_                                                     |
-| P24    | Status LED  _(inverted)_                                                           |
-| P26    | Button  _(inverted)_
+| P24    | Status LED  _(inverted)_ |
+| P26    | Button  _(inverted)_ |
+| P14    | Relay and Button LED  |
+| P8     | Light activation status, taking into account the _local_ activation (this device) xor the _remote_ activation (another device) _(inverted)_     |
 
 > **Note**: Each relay shares a pin with its associated LED.
 
@@ -74,136 +65,87 @@ To gain individual control of button LEDs, remove specific diodes and solder a w
 
 ## Configuration Examples
 
-### 1 Gang Configuration for the BK72XX device
+### Series 1 (WB3S) Configuration Examples
 
 ```yaml
 substitutions:
-  devicename: "deta-2way-single-gang"
-  friendlyname: Deta 2-way Single Gang Switch
-  deviceid: deta_single_gang_two_way
-  deviceicon: "mdi:light-recessed"
-  devicemodel: Deta Grid Connect Single Gang Two-Way 6951HA
+  device_name: "deta-2-way-1-gang-switch"
 
-#################################
+  friendly_name: "DETA 2 Way 1 Gang Switch"
+  light_1_name: "${friendly_name}"
+  light_1_icon: "mdi:light-recessed"
+
 esphome:
-  name: ${devicename}
+  name: ${device_name}
+  friendly_name: ${friendly_name}
 
 bk72xx:
-  board: generic-bk7231t-qfn32-tuya
+  board: wb3s
 
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
 
-  # Enable fallback hotspot (captive portal) in case wifi connection fails
-  ap:
-    ssid: ${devicename}
-    password: !secret fallback_password
-
-# Enable logging
 logger:
 
-captive_portal:
-
-# Enable Home Assistant API
-api:
-  encryption:
-     key: !secret esphome_api_encryption_key
-
-ota:
-  password: !secret esphome_ota_password
-
-web_server:
-  port: 80
-  auth:
-    username: !secret esphome_web_username
-    password: !secret esphome_web_password
-
-
-
-#################################
-
-## ---------------- ##
-##    Status LED    ##
-## ---------------- ##
 status_led:
   pin:
     number: P24
     inverted: true
 
-## ---------------- ##
-##      Relays      ##
-## ---------------- ##
-output:
-  # Relay
-  - platform: gpio
-    id: relay
-    pin: P14
-
-## ------------ ##
-##     Light    ##
-## ------------ ##
 light:
-  # Light - keeping as internal as I found it worked but if you used the other switch 2-way switch, that HA would say the light was off when the light was actually on.
-  # Using the Switch at the bottom of the config to keep everything in order. But then in HA you have to set the Switch that shows up to show up as a Light.
   - platform: binary
-    icon: ${deviceicon}
-    output: relay
-    id: light
-    internal: true
+    output: filter_1
+    id: light_1
+    name: "${light_1_name}"
+    icon: "${light_1_icon}"
 
-## ----------------- ##
-##      Buttons      ##
-## ----------------- ##
 binary_sensor:
-  # Button
+  # Buttons
   - platform: gpio
-    id: button
+    id: button_1
     pin:
       number: P26
       inverted: true
       mode: INPUT_PULLUP
     on_press:
       then:
-        - light.toggle: light
-    internal: True
-  
+        - light.toggle: light_1
+    internal: true
+
+  # Activation statuses
+  # Represents the "local" relay (this device) XOR the "remote" relay (another device).
+  # It only shows TRUE if one of the "local" or "remote" relays are active, but not both.
   - platform: gpio
-    id: remote_switch
+    id: activation_status_1
     pin:
       number: P8
-      mode: INPUT_PULLUP
+      mode: INPUT
       inverted: true  
-    name: "Status from both Switches"
+    internal: true
 
-
-## ---------------- ##
-##     Switches     ##
-## ---------------- ##
 switch:
-# Keep the light in HA in sync when using 2nd phyiscal switch
+  # Relay
+  - platform: gpio
+    id: relay_1
+    pin: P14
+    internal: true
+
+output:
+  # Filters
+  # Triggered when the "light" entity is turned on or off. Will only toggle
+  # the associated relay if the "light" entity is out of sync with the
+  # "activation status"; otherwise do nothing as the state is already correct.
   - platform: template
-    name: ${friendlyname}
-    id: lounge_deta_2way_single_gang_template
-    icon: ${deviceicon}
-    lambda: |-
-      if (id(remote_switch).state) {
-        return true;
-      } else {
-        return false;
-      }
-    turn_on_action:
-    - if:
-        condition:
-          - binary_sensor.is_off: remote_switch
-        then:
-          - light.toggle: light
-    turn_off_action:
-    - if:
-        condition:
-          - binary_sensor.is_on: remote_switch
-        then:
-          - light.toggle: light
+    type: binary
+    id: filter_1
+    write_action:
+      then:
+        - if:
+            condition:
+              - lambda: "return state != id(activation_status_1).state;"
+            then:
+              - switch.toggle: relay_1
 ```
 
 ### Add Reboot button to HA

--- a/src/docs/devices/DETA-Grid-Connect-Two-Gang-Two-Way-6952HA/index.md
+++ b/src/docs/devices/DETA-Grid-Connect-Two-Gang-Two-Way-6952HA/index.md
@@ -10,7 +10,7 @@ difficulty: 3
 
 ## Overview
 
-The DETA [Switch Smart Grid 2 Way 2 Gang (6951HA)](https://www.bunnings.com.au/deta-switch-smart-grid-2-way-2-gang_p0346911) is part of the [Grid Connect ecosystem](https://grid-connect.com.au/), and is sold at Bunnings in Australia.
+The DETA [Smart Switch 2 Way 2 Gang (6952HA)](https://www.bunnings.com.au/deta-switch-smart-grid-2-way-2-gang_p0346911) is part of the [Grid Connect ecosystem](https://grid-connect.com.au/), and is sold at Bunnings in Australia.
 
 ![6952HA packet](./6952HA-packet.jpg "DETA 6952HA packet, with 'Series 2' highlighted.")
 

--- a/src/docs/devices/DETA-Grid-Connect-Two-Gang-Two-Way-6952HA/index.md
+++ b/src/docs/devices/DETA-Grid-Connect-Two-Gang-Two-Way-6952HA/index.md
@@ -4,6 +4,8 @@ date-published: 2025-01-18
 type: switch
 standard: au
 board: bk72xx
+made-for-esphome: False
+difficulty: 3
 ---
 
 ## Overview
@@ -53,8 +55,8 @@ _See [Pinouts on CB3S Module Datasheet](https://developer.tuya.com/en/docs/iot/c
 | P23    | Button 2 _(inverted)_ |
 | P14    | Relay 1 and Button 1 LED |
 | P6    | Relay 2 and Button 2 LED |
-| P7     | Light 1 activation status, taking into account _this_ Light 1 switch and the _remote_ Light 1 switch _(inverted)_     |
-| P8     | Light 2 activation status, taking into account _this_ Light 2 switch and the _remote_ Light 2 switch _(inverted)_     |
+| P7     | Light 1 activation status, taking into account the _local_ activation (this device) xor the _remote_ activation (another device) _(inverted)_     |
+| P8     | Light 2 activation status, taking into account the _local_ activation (this device) xor the _remote_ activation (another device) _(inverted)_     |
 
 ## Configuration Examples
 
@@ -65,10 +67,10 @@ substitutions:
   device_name: "deta-2-way-2-gang-switch"
 
   friendly_name: "DETA 2 Way 2 Gang Switch"
-  switch_1_name: "${friendly_name} 1"
-  switch_2_name: "${friendly_name} 2"
-  switch_1_icon: "mdi:light-recessed"
-  switch_2_icon: "mdi:light-recessed"
+  light_1_name: "${friendly_name} 1"
+  light_2_name: "${friendly_name} 2"
+  light_1_icon: "mdi:light-recessed"
+  light_2_icon: "mdi:light-recessed"
 
 esphome:
   name: ${device_name}
@@ -83,35 +85,23 @@ wifi:
 
 logger:
 
-# Status LED
 status_led:
   pin:
     number: P24
     inverted: true
 
-# Relays
-output:
-  - platform: gpio
-    id: relay_1
-    pin: P14
-  - platform: gpio
-    id: relay_2
-    pin: P6
-
-# Lights
 light:
-  # Keeping these internal to avoid sync issues if the lights
-  # are switched off via the remote switch.
-  # The lights are exposed as "switch" entities instead.
   - platform: binary
-    output: relay_1
+    output: filter_1
     id: light_1
-    internal: true
+    name: "${light_1_name}"
+    icon: "${light_1_icon}"
 
   - platform: binary
-    output: relay_2
+    output: filter_2
     id: light_2
-    internal: true
+    name: "${light_2_name}"
+    icon: "${light_2_icon}"
 
 binary_sensor:
   # Buttons
@@ -136,7 +126,10 @@ binary_sensor:
       then:
         - light.toggle: light_2
     internal: true
+
   # Activation statuses
+  # Represents the "local" relay (this device) XOR the "remote" relay (another device).
+  # It only shows TRUE if one of the "local" or "remote" relays are active, but not both.
   - platform: gpio
     id: activation_status_1
     pin:
@@ -153,43 +146,44 @@ binary_sensor:
       inverted: true  
     internal: true
 
-# Switches
 switch:
+  # Relays
+  - platform: gpio
+    id: relay_1
+    pin: P14
+    internal: true
+
+  - platform: gpio
+    id: relay_2
+    pin: P6
+    internal: true
+
+output:
+  # Filters
+  # Triggered when the "light" entity is turned on or off. Will only toggle
+  # the associated relay if the "light" entity is out of sync with the
+  # "activation status"; otherwise do nothing as the state is already correct.Z
   - platform: template
-    name: ${switch_1_name}
-    id: switch_1
-    icon: ${switch_1_icon}
-    lambda: "return id(activation_status_1).state;"
-    turn_on_action:
-    - if:
-        condition:
-          - binary_sensor.is_off: activation_status_1
-        then:
-          - light.toggle: light_1
-    turn_off_action:
-    - if:
-        condition:
-          - binary_sensor.is_on: activation_status_1
-        then:
-          - light.toggle: light_1
+    type: binary
+    id: filter_1
+    write_action:
+      then:
+        - if:
+            condition:
+              - lambda: "return state != id(activation_status_1).state;"
+            then:
+              - switch.toggle: relay_1
 
   - platform: template
-    name: ${switch_2_name}
-    id: switch_2
-    icon: ${switch_2_icon}
-    lambda: "return id(activation_status_2).state;"
-    turn_on_action:
-    - if:
-        condition:
-          - binary_sensor.is_off: activation_status_2
-        then:
-          - light.toggle: light_2
-    turn_off_action:
-    - if:
-        condition:
-          - binary_sensor.is_on: activation_status_2
-        then:
-          - light.toggle: light_2
+    type: binary
+    id: filter_2
+    write_action:
+      then:
+        - if:
+            condition:
+              - lambda: "return state != id(activation_status_2).state;"
+            then:
+              - switch.toggle: relay_2
 ```
 
 ### Add Reboot button to HA


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes
Update configuration examples for DETA 6951HA and 6952HA based on optimisations I've made in my own Home Assistant setup.

This config exposes a "light" entity instead of a "switch" entity, eliminating the overhead of converting it in Home Assistant.

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
