### PR TITLE
Add section on packaged MJ-SD01 config

### DIFF
--- a/src/docs/devices/MJ-SJ01/index.md
+++ b/src/docs/devices/MJ-SJ01/index.md
@@ -34,6 +34,17 @@ The header CN is under the board, visible after removing the 4 screws.
 | CN1-5 | GROUND                    |
 | CN1-6 | VCC                       |
 
+## Light as fully-featured package
+
+[@joshuaboniface](https://github.com/joshuaboniface) has created a fully-featured, packaged configuration for this device,
+which permits quick flashing with a pre-compiled binary as well as automatic adoption, deployment, and updates.
+
+[Github Project Link](https://github.com/joshuaboniface/martinjerrymjsd01-esphome)
+
+The functionality has been modified quite significantly from the example below, to provide an experience more like a WeMo
+dimmer switch as well as provide more flexibility for control in HomeAssistant dashboards and automations. See the README
+in the repository for more information and examples.
+
 ## Light
 
 ```yaml


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Adds a link to and brief explanation of my new configuration for the MJ-SD01 switch. Hopefully this format is acceptable, since the README there is a lot more extensive than seems appropriate for an esphome-devices page, and I wanted to keep this reference relatively brief. It is added as a new section above the existing section.

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
