### PR TITLE
Update Tuya IRC03 IR Blaster and Tuya Generic IR Blaster pages

### DIFF
--- a/src/docs/devices/Tuya-Generic-IRC03-IR-Blaster/index.md
+++ b/src/docs/devices/Tuya-Generic-IRC03-IR-Blaster/index.md
@@ -10,6 +10,8 @@ board: bk72xx
 
 There's detailed teardown info at [Elektroda](https://www.elektroda.com/rtvforum/topic4012905.html).
 
+Despite appearing outwardly identical to the [Tuya Generic IR Remote Control](/devices/Tuya-Generic-WiFi-IR-Remote-Control), the IRC03 has a custom PCB with the BK7231N directly integrated into it as opposed to using the CB3S module. The pinouts between the two devices differ as a result.
+
 ![IRC03](IRC03.jpg)
 
 ## GPIO Pinout
@@ -64,4 +66,20 @@ remote_receiver:
       input: true
       pullup: true
   tolerance: 55%
+```
+
+For use with Home Assistant integrations such as SmartIR that send raw IR commands, make sure to set the IR carrier frequency to about 38KHz. Leaving it as default may cause raw IR commands to fail to work properly.
+
+```yaml
+api:
+  encryption:
+    key: "xxxxxxx"
+  services:
+    - service: send_raw_command
+      variables:
+        command: int[]
+      then:
+        - remote_transmitter.transmit_raw:
+            code: !lambda "return command;"
+            carrier_frequency: !lambda "return 38029.0;"
 ```

--- a/src/docs/devices/Tuya-Generic-IRC03-IR-Blaster/index.md
+++ b/src/docs/devices/Tuya-Generic-IRC03-IR-Blaster/index.md
@@ -28,7 +28,7 @@ Despite appearing outwardly identical to the [Tuya Generic IR Remote Control](/d
 I used ``ltchiptool`` to backup the original firmware and flash an esphome uf2 binary to it.
 The pads are all nicely labeled.
 
-As of May 2025, these devices are also vulnerable to ``tuya-cloudcutter``, allowing for disassembly-free flashing. I've had success using the generic 2.1.5 BK7231N template as well as a 2.1.5 CB3S template to flash ESPHome Kickstart to the device, from which I uploaded a proper UF2 binary. 
+As of May 2025, these devices are also vulnerable to ``tuya-cloudcutter``, allowing for disassembly-free flashing. I've had success using the generic 2.1.5 BK7231N template as well as a 2.1.5 CB3S template to flash ESPHome Kickstart to the device, from which I uploaded a proper UF2 binary.
 
 ## Configuration
 

--- a/src/docs/devices/Tuya-Generic-IRC03-IR-Blaster/index.md
+++ b/src/docs/devices/Tuya-Generic-IRC03-IR-Blaster/index.md
@@ -26,6 +26,8 @@ There's detailed teardown info at [Elektroda](https://www.elektroda.com/rtvforum
 I used ``ltchiptool`` to backup the original firmware and flash an esphome uf2 binary to it.
 The pads are all nicely labeled.
 
+As of May 2025, these devices are also vulnerable to ``tuya-cloudcutter``, allowing for disassembly-free flashing. I've had success using the generic 2.1.5 BK7231N template as well as a 2.1.5 CB3S template to flash ESPHome Kickstart to the device, from which I uploaded a proper UF2 binary. 
+
 ## Configuration
 
 ```yaml

--- a/src/docs/devices/Tuya-Generic-WiFi-IR-Remote-Control/index.md
+++ b/src/docs/devices/Tuya-Generic-WiFi-IR-Remote-Control/index.md
@@ -8,7 +8,9 @@ board: bk72xx
 
 ## General Notes
 
-This devices has a CB3S board. It can be bought at AliExpres, e.g. [here](https://www.aliexpress.com/item/1005007804859733.html) (February 2025).
+This devices has a CB3S board. It can be bought at Aliexpress, e.g. [here](https://www.aliexpress.com/item/1005007804859733.html) (February 2025).
+
+Despite appearing outwardly identical to the [Tuya Generic IRC03 IR Blaster](/devices/Tuya-Generic-IRC03-IR-Blaster), the IRC03 has a custom PCB with the BK7231N directly integrated into it as opposed to using the CB3S module. The pinouts between the two devices differ as a result.
 
 ![IRRemote](tuya-generic-wifi-ir-remote-control.jpg)
 


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Adds a disclaimer to the Tuya IRC03 and Tuya Generic IR Blaster pages warning that despite looking outwardly identical, the devices have different internals and accordingly different pinouts. Updates the IRC03 page with additional flashing information. Adds a little usage information to the IRC03 page regarding use with the Home Assistant integration SmartIR.

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
