### PR TITLE
sonoff s31: add warning about web_server

### DIFF
--- a/src/docs/devices/Sonoff-S31/index.md
+++ b/src/docs/devices/Sonoff-S31/index.md
@@ -130,3 +130,4 @@ status_led:
 - `board: esp12e` is required to enable all 4MB of flash, allowing OTA updates to work after approximately version 2024.4.0
 - `throttle_average: 60s` on cse7766 sensors is highly recommended with version 2024.2.0 or greater.
 - `restore_mode: ALWAYS_OFF` avoids potential damage or instability when using the programmer’s supply.
+- `web_server:` can cause instability due to the device's slower ESP8266 processor


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Add a warning for Sonoff S31 devices about `web_server` causing instability.

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
