### PR TITLE
Update Lanbon L8 configuration for 2025.5.0

### DIFF
--- a/src/docs/devices/lanbon_l8/index.md
+++ b/src/docs/devices/lanbon_l8/index.md
@@ -66,7 +66,6 @@ No soldering required.
 
 ```yaml
 psram:
-  mode: octal
   speed: 80MHz
 
 output:
@@ -114,17 +113,8 @@ i2c:
   scl: GPIO0
 
 display:
-  - id: langbon_L8
-    platform: ili9xxx
-    model: ST7789V
-    invert_colors: false
-    dimensions: 240x320
-    cs_pin: GPIO22
-    dc_pin: GPIO21
-    reset_pin: GPIO18
-    auto_clear_enabled: false
-    update_interval: never
-    rotation: 180
+  - platform: mipi_spi
+    model: LANBON-L8
 
 touchscreen:
   platform: ft63x6


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

With 2025.5.0, the example Lanbon-L8 configuration was generating an error because 'octal' mode is not supported for PSRAM on the ESP32.

New with 2025.5.0 is the mipi_spi platform with a built-in model for the Lanbon-L8 which greatly simplifies the configuration


## Type of changes

- [ ] New device
- [X] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [X] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [X] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [X] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
