### PR TITLE
Updated basic configuration for Sonoff POW R2

### DIFF
--- a/src/docs/devices/Sonoff-POW-R2/index.md
+++ b/src/docs/devices/Sonoff-POW-R2/index.md
@@ -31,12 +31,11 @@ over the LED in the event of a error/warning state, such as when WiFi is disrupt
 # Basic Config
 substitutions:
   update_interval: 60s
+  name: "sonoff-pow-r2"
+  ota_password: "your_ota_password_here"
 
 esphome:
-  name: "Sonoff POW R2"
-  project:
-    name: Sonoff.relay
-    version: 'POWR2'
+  name: "${name}"
 
 esp8266:
   board: esp01_1m
@@ -48,6 +47,8 @@ logger:
 api:
 
 ota:
+  - platform: esphome
+    password: "${ota_password}"
 
 wifi:
   networks:
@@ -57,6 +58,7 @@ wifi:
 uart:
   rx_pin: RX
   baud_rate: 4800
+  parity: EVEN
 
 binary_sensor:
   - platform: gpio


### PR DESCRIPTION
The [currently available code listing](https://devices.esphome.io/devices/Sonoff-POW-R2#basic-configuration) fails with compilation (in esphome v2025.4.0) errors due to invalid characters in name, missing platform for OTA and missing explicit parity setting for UART.

I assume all errors are caused by some breaking changes that piled up in esphome while this listing was not updated.

Example compilation error caused by invalid characters in name:

```
esphome compile powr2-example.yaml
INFO ESPHome 2025.4.0
INFO Reading configuration powr2-example.yaml...
Failed config

esphome: [source powr2-example.yaml:6]

  'S' is an invalid character for names. Valid characters are: abcdefghijklmnopqrstuvwxyz0123456789-_ (lowercase, no spaces).
  name: Sonoff POW R2
  project:
    name: Sonoff.relay
    version: POWR2
```

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

* Simplified esphome.name.
* I removed `project` section all-together as it is not necessary to make a build and reduces clarity.
* Added a required `platform` property for `ota`.
* I have explicitly set bit parity for UART (that's required by power sensing chip)
	<details><summary>Here's compilation output without bit parity set</summary>

	```

	esphome compile powr2-example.yaml
	INFO ESPHome 2025.4.0
	INFO Reading configuration powr2-example.yaml...
	Failed config

	uart: [source powr2-example.yaml:27]
	- rx_pin:
		number: 3
		mode:
			input: True
			output: False
			open_drain: False
			pullup: False
			pulldown: False
			analog: False
		inverted: False
		baud_rate: 4800
		rx_buffer_size: 256
		stop_bits: 1
		data_bits: 8

		Component cse7766 requires parity EVEN for the uart referenced by uart_id.
		parity: NONE

	```
	</details> 

## Suggestion on simplifying code by removing dummy button

While doing this I noticed that [`switch.dummybutton`](https://github.com/esphome/esphome-devices/blob/93fa745fcf53621ff4879bd0c81c60432f85bc2b/src/docs/devices/Sonoff-POW-R2/index.md#L99-L106) is redundant in this code listing. [It's used by GPIO sensor](https://github.com/esphome/esphome-devices/blob/93fa745fcf53621ff4879bd0c81c60432f85bc2b/src/docs/devices/Sonoff-POW-R2/index.md#L68-L69) to indirectly toggle the relay.

Instead I think dummy button could be removed and GPIO should call `switch.toggle: relay` directly, reducing the code overhead. If you'd like this simplification I'm happy to contribute change in a followup PR.

## Type of changes

- [ ] New device
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [x] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
