### PR TITLE
Fix compilation for M5StickC-Plus

### DIFF
--- a/src/docs/devices/M5Stack-M5StickC-PLUS/index.md
+++ b/src/docs/devices/M5Stack-M5StickC-PLUS/index.md
@@ -13,22 +13,22 @@ project-url: https://docs.m5stack.com/en/core/m5stickc_plus
 
 ## GPIO Pinout
 
-| Pin    | Function          |
-| ------ | ----------------- |
-| GPIO37 | Button A          |
-| GPIO39 | Button B          |
-| GPIO10 | Internal LED      |
-| GPIO09 | Infrared LED      |
-| GPIO13 | SPI CLK           |
-| GPIO15 | SPI MOSI          |
-| GPIO21 | I2C SDA           |
-| GPIO22 | I2C SCL           |
-| GPIO05 | Display CS        |
-| GPIO23 | Display DC        |
-| GPIO19 | Display Reset     |
-| GPIO00 | I2S CLK           |
-| GPIO26 | I2S LRCLK         |
-| GPIO35 | Microphone Data   |
+| Pin    | Function        |
+| ------ | --------------- |
+| GPIO37 | Button A        |
+| GPIO39 | Button B        |
+| GPIO10 | Internal LED    |
+| GPIO09 | Infrared LED    |
+| GPIO13 | SPI CLK         |
+| GPIO15 | SPI MOSI        |
+| GPIO21 | I2C SDA         |
+| GPIO22 | I2C SCL         |
+| GPIO05 | Display CS      |
+| GPIO23 | Display DC      |
+| GPIO19 | Display Reset   |
+| GPIO00 | I2S CLK         |
+| GPIO26 | I2S LRCLK       |
+| GPIO35 | Microphone Data |
 
 ## External Component
 
@@ -54,7 +54,7 @@ esp32:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
-  
+
   ap:
     ssid: $devicename Fallback Hotspot
     password: !secret wifi_password
@@ -66,6 +66,7 @@ logger:
 api:
 
 ota:
+  platform: esphome
 
 external_components:
   - source: github://martydingo/esphome-axp192
@@ -74,6 +75,7 @@ external_components:
 # AXP192 power management - must be present to initialize TFT power on
 sensor:
   - platform: axp192
+    model: M5STICKC
     address: 0x34
     i2c_id: bus_a
     update_interval: 30s
@@ -108,7 +110,7 @@ binary_sensor:
 
 light:
   - platform: monochromatic
-    output:  builtin_led
+    output: builtin_led
     name: ${upper_devicename} Led
     id: led1
 
@@ -122,17 +124,16 @@ remote_transmitter:
   - pin:
       number: GPIO9
     carrier_duty_percent: 50%
-    id: internal
 
 spi:
   clk_pin: GPIO13
   mosi_pin: GPIO15
 
 i2c:
-   - id: bus_a
-     sda: GPIO21
-     scl: GPIO22
-     scan: True
+  - id: bus_a
+    sda: GPIO21
+    scl: GPIO22
+    scan: True
 
 font:
   - file: "gfonts://Roboto"
@@ -141,14 +142,13 @@ font:
 
 # 1.14 inch, 135*240 Colorful TFT LCD, ST7789v2
 display:
-  - platform:  st7789v
+  - platform: st7789v
     model: TTGO TDisplay 135x240
     cs_pin: GPIO5
     dc_pin: GPIO23
     reset_pin: GPIO18
     rotation: 270
-    lambda: |-
-      it.print(80, 0, id(roboto), ST77XX_WHITE, TextAlign::TOP_CENTER, "M5Stick Test");
+    show_test_card: true
 
 i2s_audio:
   id: bus_i2s
@@ -170,18 +170,18 @@ The 5V power on the HY2.0-4P is fed by the axp192. Therefore these devices must 
 
 ```yml
 i2c:
-   - id: bus_grove
-     sda: GPIO32
-     scl: GPIO33
-     scan: True
-     frequency: 100kHz
-     ## Start after the axp192 has powered up
-     ## In case an additional delay is needed this component may be helpful:
-     ## https://github.com/ssieb/esphome_components/tree/master/components/boot_delay
-     setup_priority: 500
+  - id: bus_grove
+    sda: GPIO32
+    scl: GPIO33
+    scan: True
+    frequency: 100kHz
+    ## Start after the axp192 has powered up
+    ## In case an additional delay is needed this component may be helpful:
+    ## https://github.com/ssieb/esphome_components/tree/master/components/boot_delay
+    setup_priority: 500
 
 sensor:
- ## Example: anything connected to "i2c_id: bus_grove" should have a lower setup priority than bus_grove.
+  ## Example: anything connected to "i2c_id: bus_grove" should have a lower setup priority than bus_grove.
   - platform: scd30
     setup_priority: 490
     i2c_id: bus_grove

--- a/src/docs/devices/M5Stack-M5StickC-PLUS2/index.md
+++ b/src/docs/devices/M5Stack-M5StickC-PLUS2/index.md
@@ -67,6 +67,7 @@ logger:
 api:
 
 ota:
+  platform: esphome
 
 # Battery voltage measured through ADC1_CH2. PLUS2 has a voltage divider,
 # so reading needs to be multiplied by 2


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Fix compilation for M5StickC-Plus

Note: compiles successfully, but untested due to lack of hardware
(therefore I didn't migrate the display to `ili9xxx`).

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other

## Checklist:

- [x] There are no passwords or secrets references in any examples.
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
