### PR TITLE
Update ESP-12F_Relay_X8 GPIO header

### DIFF
--- a/src/docs/devices/ESP-12F-Relay-X8/index.md
+++ b/src/docs/devices/ESP-12F-Relay-X8/index.md
@@ -10,61 +10,53 @@ board: esp8266
 
 ## Product description
 
-This is a 8-relay board with an ESP-12F.
+This is an 8-relay board with an [ESP-12F](https://docs.ai-thinker.com/_media/esp8266/docs/esp-12f_product_specification_en.pdf).
 
 Each relay has COM+NO+NC exposed. Product descriptions don't seem to specify maximum load.
 
-The board can be powered either via 7-30VDC or via 5VDC (separate connectors).
+The board can be powered either via 7-30VDC or via 5VDC via the screw terminals. Power the board with the screw terminals for flashing.
 
 I bought it from: https://s.click.aliexpress.com/e/_DnEOi2r (affiliation link so i can make others like this, no guarantee it will continue to exist).
 
+## GPIO Header
+
+This board has headers for a few GPIO pins on its ESP-12F.
+
+| Pin   | Comment                                                   |
+| ----- | --------------------------------------------------------- |
+| 5V    | Do not use 5V for programming. Power via screw terminals. |
+| TX    | Exposed on board 3.3V level! UART0_TX                     |
+| RX    | Exposed on board 3.3V level! UART0_RX                     |
+| GPIO0 | 3.3V level! (pulled up, connect to GND for programming)   |
+| GND   |                                                           |
+| GND   |                                                           |
+| GPIO2 | UART1_TX                                                  |
+| ADC   |                                                           |
+
 ## GPIO Pinout
 
-This board has headers for every GPIO pin on its ESP-12F.
-
-| Pin   | Comment                                                 |
-| ----- | ------------------------------------------------------- |
-| 5V    | Do not use 5V for programming                           |
-| TX    | Exposed on board 3.3V level!                            |
-| RX    | Exposed on board 3.3V level!                            |
-| GPIO0 | 3.3V level! (pulled up, connect to GND for programming) |
-| GND   |                                                         |
-| GND   |                                                         |
+Be aware that relay 1 and 6 will be momentarily toggled on during boot.
 
 | Pin    | Comment                                       |
 | ------ | --------------------------------------------- |
-| 3V3    | For programming, inject 3.3V power here       |
-| 3V3    | For programming, inject 3.3V power here       |
-| 5V     |                                               |
-| 5V     |                                               |
-| GND    |                                               |
-| GND    |                                               |
-|        |                                               |
-| GPIO5  | Relay 8                                       |
-| GPIO4  | Relay 7                                       |
-| GPIO0  | Relay 6                                       |
+| GPIO0  | Relay 6 (high on boot)                        |
 | GPIO2  | Exposed on board | (blue) LED on the ESP-12F  |
+| GPIO4  | Relay 7                                       |
+| GPIO5  | Relay 8                                       |
+| GPIO12 | Relay 3                                       |
+| GPIO13 | Relay 4                                       |
+| GPIO14 | Relay 2                                       |
 | GPIO15 | Relay 5                                       |
-| GND    |                                               |
-
-| Pin    | Comment                                 |
-| ------ | --------------------------------------- |
-| ADC    | Exposed on board ( 0V-1V only )         |
-| EN     | Pulled up                               |
-| GPIO16 | Relay 1                                 |
-| GPIO14 | Relay 2                                 |
-| GPIO12 | Relay 3                                 |
-| GPIO13 | Relay 4                                 |
+| GPIO16 | Relay 1 (high on boot)                        |
 
 ## Basic Config
 
 ```yaml
 esphome:
   name: relayboard
-  platform: ESP8266
+
+esp8266:
   board: esp12e
-
-
 
 # Status LED
 light:


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

- Split the intertwined GPIO info into header and pinout sections.
    - Notate which relays will be on during boot.
- Add link to an ESP-12F datasheet.
- Clarify how to power the board for flashing.


## Type of changes

- [ ] New device
- [X] Update existing device
- [ ] Removing a device
- [X] General cleanup
- [ ] Other


## Checklist:

- [X] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [X] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [X] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
