### PR TITLE
KASPS10A3P3UA - use `platform: status_led`; allow outlet selection with multi_click

### DIFF
--- a/src/docs/devices/Kogan-Smarterhome-Smart-Power-Board-With-Usb-Ports-Energy-Meter/index.md
+++ b/src/docs/devices/Kogan-Smarterhome-Smart-Power-Board-With-Usb-Ports-Energy-Meter/index.md
@@ -77,20 +77,51 @@ binary_sensor:
       mode: INPUT_PULLUP
       inverted: true
     name: "${device_name}_button"
-    on_press:
-      - switch.toggle: relay3
+    on_multi_click:
+      - timing:
+          - ON for 5ms to 350ms
+          - OFF for at least 750ms
+        then:
+          - switch.toggle: relayusb
+      - timing:
+          - ON for 5ms to 350ms
+          - OFF for 5ms to 350ms
+          - ON for 5ms to 350ms
+          - OFF for at least 750ms
+        then:
+          - switch.toggle: relay1
+      - timing:
+          - ON for 5ms to 350ms
+          - OFF for 5ms to 350ms
+          - ON for 5ms to 350ms
+          - OFF for 5ms to 350ms
+          - ON for 5ms to 350ms
+          - OFF for at least 750ms
+        then:
+          - switch.toggle: relay2
+      - timing:
+          - ON for 5ms to 350ms
+          - OFF for 5ms to 350ms
+          - ON for 5ms to 350ms
+          - OFF for 5ms to 350ms
+          - ON for 5ms to 350ms
+          - OFF for 5ms to 350ms
+          - ON for 5ms to 350ms
+          - OFF for at least 750ms
+        then:
+          - switch.toggle: relay3
 
   - platform: status
     name: "${device_name}_status"
 
-switch:
-  - platform: gpio
+light:
+  - platform: status_led
     id: green_led
     pin:
       number: GPIO1
       inverted: true
-    restore_mode: ALWAYS_OFF
 
+switch:
   - platform: gpio
     name: "${device_name}_plug1"
     pin: GPIO13
@@ -112,9 +143,9 @@ switch:
     icon: ${plug_icon}
     restore_mode: ${plug3_restore}
     on_turn_on:
-      - switch.turn_on: green_led
+      - light.turn_on: green_led
     on_turn_off:
-      - switch.turn_off: green_led
+      - light.turn_off: green_led
 
   - platform: gpio
     name: "${device_name}_usb"

--- a/src/docs/devices/Kogan-Smarterhome-Smart-Power-Board-With-Usb-Ports-Energy-Meter/index.md
+++ b/src/docs/devices/Kogan-Smarterhome-Smart-Power-Board-With-Usb-Ports-Energy-Meter/index.md
@@ -8,7 +8,7 @@ board: esp8266
 ---
   ![alt text](kogan-smarterhome-smart-power-board-with-usb-ports-energy-meter.jpg "Product Image")
 
-[https://www.kogan.com/au/buy/kogan-smarterhome-smart-power-board-with-usb-ports-energy-meter/](https://www.kogan.com/au/buy/kogan-smarterhome-smart-power-board-with-usb-ports-energy-meter/)
+[Kogan SmarterHome™ Smart Power Board With USB Ports & Energy Meter - (KASPS10A3P3UA) - Manual](https://help.kogan.com/s/article/KoganSmarterHomeSmartPowerBoardWithUSBPortsEnergyMeterKASPS10A3P3UAManual)
 
 ## GPIO Pinout
 


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

* use `light: platform: status_led` (which was implemented after this template was first written)
* allow selection of relay to toggle with multi_click
* no longer listed for sale, point to manual instead

I'm not sure if relay selection adheres to the last checklist item, but this restores functionality.

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [?] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
