### PR TITLE
Add difficulty and pin 6 to UltraPro WFD4001.

### DIFF
--- a/src/docs/devices/UltraPro-WFD4001-Light-Switch/index.md
+++ b/src/docs/devices/UltraPro-WFD4001-Light-Switch/index.md
@@ -5,19 +5,30 @@ type: switch
 standard: us
 board: bk72xx
 pcb: WB3S
+difficulty: 2
 ---
 ![Product Image](./ultrapro-wfd4001-light-switch-v1.1.14.jpg "Device front")
 
 ## GPIO Pinout
 
-| Pin | Alternate Pin Name | Function   | Active |
-| --- | ------------------ | ---------- | ------ |
-| P8  | PWM2               | On Button  | Low    |
-| P9  | PWM3               | Off Button | Low    |
-| P24 | PWM4               | Status Led | High   |
-| P6  | PWM5               | Relay      | High   |
+| Pin | Alternate Pin Name | Function     | Active |
+| --- | ------------------ | ------------ | ------ |
+| P6  | PWM0               | Reset Button | Low    |
+| P8  | PWM2               | On Button    | Low    |
+| P9  | PWM3               | Off Button   | Low    |
+| P24 | PWM4               | Status Led   | High   |
+| P6  | PWM5               | Relay        | High   |
+
+## Tuya Cloudcutter
+
+The board is easily flashed without disassembly using
+[tuya-cloudcutter](https://github.com/tuya-cloudcutter/tuya-cloudcutter).
 
 ## Basic Configuration
+
+On and off will activate the relay.  Holding the reset button for more
+than 5 seconds will reset the wifi password and revert the device to
+the captive portal.
 
 ```yaml
 # You should only need to modify the substitutions.
@@ -37,10 +48,9 @@ logger:
 api:
 captive_portal:
 ota:
+  - platform: esphome
 
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
+wifi: # Get the SSID and password from the captive portal.
   ap:
 
 output:
@@ -54,6 +64,19 @@ switch:
     name: None
     restore_mode: RESTORE_DEFAULT_OFF
     device_class: switch
+    on_turn_on:
+      then:
+        - light.turn_on: blue_led
+    on_turn_off:
+      then:
+        - light.turn_off: blue_led
+button:
+  - platform: restart
+    id: do_restart
+    name: "Restart"
+  - platform: factory_reset
+    id: do_factory_reset
+    name: "Factory Reset to AP mode"
 binary_sensor:
   - platform: gpio
     pin:
@@ -62,7 +85,6 @@ binary_sensor:
     id: input_on_button
     on_press:
       then:
-        - light.turn_on: blue_led
         - switch.turn_on: relay
   - platform: gpio
     pin:
@@ -71,8 +93,39 @@ binary_sensor:
     id: input_off_button
     on_press:
       then:
-        - light.turn_off: blue_led
         - switch.turn_off: relay
+  - platform: gpio
+    pin:
+      number: PWM0
+      inverted: True # The config button is active low.
+    id: input_config_button
+    on_press:
+      then:
+        - while:
+            condition:
+              - binary_sensor.is_on: input_config_button
+            then:
+              - light.toggle: blue_led
+              - delay: 250ms
+    on_release:
+      then:
+        - if:
+            condition:
+              - switch.is_on: relay
+            then:
+              - light.turn_on: blue_led
+            else:
+              - light.turn_off: blue_led
+    on_click:
+      - min_length: 5s
+        max_length: 100s
+        then:
+          - repeat:
+              count: 6
+              then:
+                - light.toggle: blue_led
+                - delay: 100ms
+          - button.press: do_factory_reset
 light:
   - platform: status_led
     id: blue_led


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Add difficult and pin 6 description to UltraPro WFD4001.

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
