### PR TITLE
Add Apollo PUMP-1

### DIFF
--- a/src/docs/devices/Apollo-Automation-PUMP-1/index.md
+++ b/src/docs/devices/Apollo-Automation-PUMP-1/index.md
@@ -1,0 +1,42 @@
+---
+title: Apollo Pump Controller (PUMP-1)
+date-published: 2025-07-10
+type: sensor
+standard: global
+board: esp32
+project-url: https://github.com/ApolloAutomation/PUMP-1
+difficulty: 1
+made-for-esphome: true
+---
+
+## Description
+
+The Apollo Automation PUMP-1 is a food safe liquid pump controller with the following features:
+
+- Pump liquids a source to an output. Watering plants, filling coffee machine, draining robot vacuum or fill your dogs water bowl
+- Detect when source liquid level is low
+- Pump until output container is full ( Topping off a fish tank or coffee machine )
+- RGB Pixels: Notify you of the status
+- Buzzer: Can play beeps, and RTTTL tones when outside a specified temperature range
+- Bluetooth tracking and Bluetooth proxy
+
+## Mounting
+
+- Optional 1L bottle available with stand
+- Or simply mount the pump to any surface
+
+## Quickstart
+
+1. Plug in the PUMP-1 into USB power.
+2. Connect to "PUMP-1 Hotspot".
+3. Input WiFi credentials.
+4. In Home Assistant, look at discovered devices.
+5. If you'd like to switch to the ethernet version please follow the guide on our wiki
+
+## Links
+
+- [Shop](https://apolloautomation.com/products/pump-1-fluid-pump?utm_source=esphome&utm_medium=social)
+- [GitHub](https://github.com/ApolloAutomation/PUMP-1)
+- [Wiki](https://wiki.apolloautomation.com/)
+- [Discord](https://dsc.gg/ApolloAutomation)
+- [YouTube](https://www.youtube.com/@ApolloAutomation)


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes
Add the Apollo PUMP-1 to made for esphome


## Type of changes

- [x] New device
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
