### PR TITLE
fixed M5 AirQ YAML for ESPhome 2025.7.x compatibility by removing rmt…

### DIFF
--- a/src/docs/devices/M5Stack-AirQ/index.md
+++ b/src/docs/devices/M5Stack-AirQ/index.md
@@ -158,11 +158,11 @@ light:
     rgb_order: GRB
     pin: GPIO21
     num_leds: 1
-    rmt_channel: 0
     chipset: SK6812
     name: "LED"
     restore_mode: RESTORE_AND_ON
     id: id_led
+    color_correct: [20%, 20%, 20%]
 
 text_sensor:
   - platform: wifi_info


### PR DESCRIPTION
…_channel

I removed the rmt_channel configuration line since it is no longer  accepted, and also added a row to make the LED more dim, since the above change made it too bright.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes



## Type of changes

- [ ] New device
- [X] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [ ] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [ ] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [ ] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
