### PR TITLE
Update HA API to enable RTTTL Buzzer actions.

### DIFF
--- a/src/docs/devices/waveshare-6ch-relay/index.md
+++ b/src/docs/devices/waveshare-6ch-relay/index.md
@@ -46,6 +46,14 @@ logger:
 # Enable Home Assistant API
 api:
     password: !secret api_password
+  # RTTTL play can be called from Dev Tools or from Scritps. 
+  actions:
+  - action: rtttl_play
+    variables:
+      song_str: string
+    then:
+      - rtttl.play:
+          rtttl: !lambda 'return song_str;'
 
 ota:
   - platform: esphome
@@ -60,6 +68,9 @@ captive_portal:
 
 web_server:
   port: 80
+
+bluetooth_proxy:
+  active: true
 
 time:
   - platform: homeassistant


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

Added action section to api section so that RTTTL buzzer can be used. Configs referenced from:
https://esphome.io/components/rtttl/ 

Also updated config to enable BT Proxy for Home Assistant.

## Type of changes

- [ ] New device
- [ ✓ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [✓ ] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [ ✓] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [✓ ] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
