### PR TITLE
Update index.md

### DIFF
--- a/src/docs/devices/Antsig-Grid-Connect-Smart-IR-Universal-Remote/index.md
+++ b/src/docs/devices/Antsig-Grid-Connect-Smart-IR-Universal-Remote/index.md
@@ -12,8 +12,7 @@ Sold at Bunnings in Australia. Model number HUBIR01HA. Based on the CB3S module,
 
 This configuration provides climate control but the device is a generic IR blaster that can control a wide range of IR devices.
 
-Flashing is achieved by popping off the top cover and soldering to easily accessible pads for UART.
-tuya-cloudcutter is untested - it may work but it's quite an easy device to flash by serial.
+Flashing can be achieved by popping off the top cover and soldering to easily accessible pads for UART, or OTA by using tuya-cloudcutter.
 
 ## GPIO Pinout
 
@@ -24,7 +23,7 @@ tuya-cloudcutter is untested - it may work but it's quite an easy device to flas
 | P8 | Status LED |
 | P26 | IR Blaster Output |
 
-## Flashing
+## Flashing via UART
 
 - Open the blaster by prising off the translucent top - it's not glued or welded but does have a fair few clips holding it together
 - Solder wires to the pads for 3V3, RST, TX, RX, and GND
@@ -34,6 +33,25 @@ tuya-cloudcutter is untested - it may work but it's quite an easy device to flas
   - This can take a few goes sometimes
 - Once flashed, disconnect the wires and power from USB - any further updates you need to make can be done OTA (which is usually much faster)
 - Take care when replacing the top - the clips aren't evenly spaced so you'll need to line them up right for it to go back together
+
+## Alternative using tuya-cloudcutter
+
+[Cloudcutter](https://github.com/tuya-cloudcutter/tuya-cloudcutter) is a tool designed to simplify the process of flashing Tuya-based devices. It allows you to bypass the need for physically opening the device and swapping out chips. By leveraging the cloud APIs, Cloudcutter enables you to flash the firmware remotely, making it a convenient and less intrusive option.
+
+After cloning the tuya-cloudcutter git repository, run the tuya-cloudcutter script and once the docker image has successfully been built, make the following selections:
+- When prompted with "Select your desired operation" enter "2" for "Flash 3rd Party Firmware"
+- When prompted with "How do you want to choose the device?", choose "device-profiles (i.e. custom profile)"
+- When prompted with "Select device profile", choose "tuya-generic-universal-ir-remote-control-cb3s-v2.0.0"
+- Cloudcutter will then make a few checks on ports in use on your host and may prompt you to stop some running services to release them for it to use. You will have to accept (press "y") to proceed with the OTA exploit
+- Once you are prompted with "Select your custom firmware file for BK7231N chip", choose the "ESPHome-Kickstart" option. Don't worry if it is not the latest version, this firmware is generic and will only be used to flash your custom ESPHome firmware later
+- From here, Cloudcutter will prompt you to put the device into AP mode, indicated by the slow blinking LED. To do so, power up the hub and press and hold the "reset" button underneath for 5-10s and then release it. The LED should blink slowly, staying on for more than a second each time. If it is blinking fast, approximately 8 times every 5 seconds according to the manual, just press and hold the reset button for another 5-10s and release and it should switch to the slow blinking AP mode.
+- As soon as the device enters AP mode, Cloudcutter should find the "GRID-xxxx" AP name and begin running the exploit
+- It will then ask you to powercycle the device and enter AP mode again. Follow the instructions exactly
+- This time, Cloudcutter will find the new AP name "A-xxxx" and proceed to connect and flash the ESPHome Kickstart firmware
+- Once complete, the device will reboot once more and Cloudcutter will terminate.
+- Build and download your custom firmware as a UF2 package.
+- Search for and connect to the new "Kickstart-xxxx" access point
+- Point your favourite browser to the ".1" IP address of the wifi subnet, ie 192.168.4.1, and use the OTA update to load your custom UTF2 firmware
 
 ## Example Configuration
 

--- a/src/docs/devices/Antsig-Grid-Connect-Smart-IR-Universal-Remote/index.md
+++ b/src/docs/devices/Antsig-Grid-Connect-Smart-IR-Universal-Remote/index.md
@@ -39,6 +39,7 @@ Flashing can be achieved by popping off the top cover and soldering to easily ac
 [Cloudcutter](https://github.com/tuya-cloudcutter/tuya-cloudcutter) is a tool designed to simplify the process of flashing Tuya-based devices. It allows you to bypass the need for physically opening the device and swapping out chips. By leveraging the cloud APIs, Cloudcutter enables you to flash the firmware remotely, making it a convenient and less intrusive option.
 
 After cloning the tuya-cloudcutter git repository, run the tuya-cloudcutter script and once the docker image has successfully been built, make the following selections:
+
 - When prompted with "Select your desired operation" enter "2" for "Flash 3rd Party Firmware"
 - When prompted with "How do you want to choose the device?", choose "device-profiles (i.e. custom profile)"
 - When prompted with "Select device profile", choose "tuya-generic-universal-ir-remote-control-cb3s-v2.0.0"


### PR DESCRIPTION
Added cloudcutter method for uploading custom FW.

Verified by running the process on 3 different HUBIR01HA units

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Added instructions for using tuya-cloudcutter to load custom firmware without opening the device and soldering wires to the board

## Type of changes

- [ ] New device
- [X] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [X] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [X] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [X] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
