### PR TITLE
Fix for OTA Platform for ESPHome 2025.7+

### DIFF
--- a/src/docs/devices/LSPS5-Tuya-1-2-3-Gang-Switch/index.md
+++ b/src/docs/devices/LSPS5-Tuya-1-2-3-Gang-Switch/index.md
@@ -73,6 +73,7 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 wifi:
   ssid: !secret wifi_ssid
@@ -141,6 +142,7 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 wifi:
   ssid: !secret wifi_ssid
@@ -223,6 +225,7 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 wifi:
   ssid: !secret wifi_ssid
@@ -355,6 +358,7 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 wifi:
   ssid: !secret wifi_ssid


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Fix for OTA Platform for ESPHome 2025.7+

```
INFO Generating C++ source...
Traceback (most recent call last):
  File "/usr/local/bin/esphome", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/esphome/esphome/__main__.py", line 1087, in main
    return run_esphome(sys.argv)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/esphome/esphome/__main__.py", line 1074, in run_esphome
    rc = POST_CONFIG_ACTIONS[args.command](args, config)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/esphome/esphome/__main__.py", line 512, in command_run
    exit_code = write_cpp(config)
                ^^^^^^^^^^^^^^^^^
  File "/esphome/esphome/__main__.py", line 212, in write_cpp
    generate_cpp_contents(config)
  File "/esphome/esphome/__main__.py", line 219, in generate_cpp_contents
    for name, component, conf in iter_component_configs(CORE.config):
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/esphome/esphome/config.py", line 61, in iter_component_configs
    p_name = f"{domain}.{p_config[CONF_PLATFORM]}"
                         ~~~~~~~~^^^^^^^^^^^^^^^
TypeError: 'int' object is not subscriptable
```

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [ ] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
