### PR TITLE
Update Lanbon L9 configuration

### DIFF
--- a/src/docs/devices/Lanbon-L9/index.md
+++ b/src/docs/devices/Lanbon-L9/index.md
@@ -36,6 +36,7 @@ difficulty: 2
 | GPIO9  | Data D5 |
 | GPIO46 | Data D6 |
 | GPIO3  | Data D7 |
+| GPIO4  | Reset Pin |
 
 ### I²C (used for touchscreen)
 
@@ -136,6 +137,7 @@ display:
     spi_id: display_spi
     bus_mode: octal
     dc_pin: GPIO17
+    reset_pin: GPIO4
     dimensions:
       height: 320
       width: 170
@@ -311,6 +313,7 @@ display:
     spi_id: display_spi
     bus_mode: octal
     dc_pin: GPIO17
+    reset_pin: GPIO4
     dimensions:
       height: 320
       width: 170


### PR DESCRIPTION
The L9-HS has been updated (my PCB shows 20250225) and the display will not work unless the reset pin is added to the display config : https://i.postimg.cc/t45gvdB2/l9v2.jpg I do not know if this impacts the previous version of this device (physical case also slightly different) as I do not have one to test. Adding "reset_pin: GPIO4" enabled the device to boot and work as expected. Without this it would not boot.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Update the Lanbon L9-HS config to work with the newer devices shipping in NA.

## Type of changes

- [ ] New device
- [ ] Update existing device
- [ ] Removing a device
- [x] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
