### PR TITLE
Fix for issue 1201

### DIFF
--- a/src/docs/devices/Sonoff-T1-T2-T3/index.md
+++ b/src/docs/devices/Sonoff-T1-T2-T3/index.md
@@ -14,6 +14,11 @@ using ESPHome.
 ## T1
 
 ``` yaml
+esphome:
+  name: "sonoff-t1"
+  friendly_name: Sonoff T1
+  name_add_mac_suffix: false
+
 esp8266:
   board: esp01_1m
 
@@ -53,6 +58,11 @@ status_led:
 ## T2
 
 ``` yaml
+esphome:
+  name: "sonoff-t2"
+  friendly_name: Sonoff T2
+  name_add_mac_suffix: false
+
 esp8266:
   board: esp01_1m
 
@@ -113,6 +123,11 @@ status_led:
 ## T3
 
 ``` yaml
+esphome:
+  name: "sonoff-t3"
+  friendly_name: Sonoff T3
+  name_add_mac_suffix: false
+
 esp8266:
   board: esp01_1m
 


### PR DESCRIPTION
this one fixes issue https://github.com/esphome/esphome-devices/issues/1201 and include the missing part with esphome definitions

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

fixes issue https://github.com/esphome/esphome-devices/issues/1201 and include the missing part with esphome definitions in the configuration provided

## Type of changes

- [ ] New device
- [X] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [X] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [X] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [X] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
