### PR TITLE
add ignore_strapping_warning, correct status_led in esp32_relay_x8's config

### DIFF
--- a/src/docs/devices/ESP32E-Relay-X8/index.md
+++ b/src/docs/devices/ESP32E-Relay-X8/index.md
@@ -48,14 +48,13 @@ esphome:
 
 esp32:
   board: esp32dev
+  framework:
+    type: esp-idf
 
 # Status LED
-light:
-  - platform: status_led
-    name: "RelayBoard Led"
-    restore_mode: ALWAYS_ON
-    pin:
-      number: GPIO23
+status_led:
+  pin:
+    number: 23
 
 # 8 relay outputs, exposed as switches in Home Assistant
 switch:
@@ -84,7 +83,9 @@ switch:
     name: Relay6
     id: relay6
   - platform: gpio
-    pin: GPIO12
+    pin:
+      number: 12
+      ignore_strapping_warning: true
     name: Relay7
     id: relay7
   - platform: gpio


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes



## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
