### PR TITLE
Inverted the button's logic level in the Sonoff s60 listing

### DIFF
--- a/src/docs/devices/Sonoff-S60TPF/index.md
+++ b/src/docs/devices/Sonoff-S60TPF/index.md
@@ -70,6 +70,7 @@ binary_sensor:
     internal: true
     pin:
       number: GPIO9
+      inverted: true
     on_press:
       - switch.toggle: switch_1
     filters:


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Turned the device has the button pulled low when activated. It's even described on [this same page](https://github.com/esphome/esphome-devices/blob/713231ded37c9bd853d9c52fcb422ae670d4c2e6/src/docs/devices/Sonoff-S60TPF/index.md#L17).

> Push Button (HIGH = off, LOW = on)

Without this more advanced tings like differentiation long presses, from short or double wouldn't work and I needed that. Like so:

```
binary_sensor:
  - platform: gpio
    pin:
      number: "${button_pin}"
      mode: INPUT
      inverted: true
    name: "Toggle button"
    filters:
      - delayed_on: 70ms
      - delayed_off: 70ms
    on_multi_click:
      # Double press.
      - timing:
          - ON for at most 1s
          - OFF for at most 1s
          - ON for at most 1s
          - OFF for at least 0.2s
        then:
          - logger.log: "Double Clicked"
      # Long press.
      - timing:
          - ON for at least 1200ms
        then:
          - logger.log: "Single Long Clicked"
      # Short press.
      - timing:
          - ON for at most 1s
          - OFF for at least 0.5s
        then:
          - logger.log: "Single Short Clicked"
```

## Type of changes

- [ ] New device
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [x] Other: documentation change


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
